### PR TITLE
Pass retain flag along in async publish

### DIFF
--- a/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClient+async.swift
+++ b/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClient+async.swift
@@ -72,7 +72,7 @@ extension MQTTClient {
     ///     - qos: Quality of Service for message.
     ///     - retain: Whether this is a retained message.
     public func publish(to topicName: String, payload: ByteBuffer, qos: MQTTQoS, retain: Bool = false) async throws {
-        return try await self.publish(to: topicName, payload: payload, qos: qos).get()
+        return try await self.publish(to: topicName, payload: payload, qos: qos, retain: retain).get()
     }
 
     /// Subscribe to topic


### PR DESCRIPTION
Add test to check
Clean up tests to use task groups