### PR TITLE
ci: Use eclipse-mosquitto image instead of custom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,19 +55,29 @@ jobs:
     container:
       image: ${{ matrix.tag }}
     services:
-      # need to update docker image if you update the certificates
-      # run `build-docker-ci-image.sh` 
       mosquitto:
-        image: adamfowlerphoto/mqttnio-mosquitto
+        image: eclipse-mosquitto
+        options: --name mosquitto
         ports:
           - 1883:1883
           - 1884:1884
           - 8883:8883
           - 8080:8080
           - 8081:8081
+        volumes:
+          - ${{ github.workspace }}/mosquitto/config:/mosquitto/config
+          - ${{ github.workspace }}/mosquitto/certs:/mosquitto/certs
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Restart Mosquitto
+      # The mosquitto service container is started *before* mqtt-nio is checked
+      # out. Restarting the container after the checkout step is needed for the
+      # container to see volumes populated from the checked out workspace.
+      uses: docker://docker
+      with:
+        args: docker restart mosquitto
     - name: Test
       env:
         MOSQUITTO_SERVER: mosquitto


### PR DESCRIPTION
A fundamental problem with service containers in GitHub Actions is that containers are started before the repository is checked out. This means that any configuration for the service that exists in the repo cannot simply be provided to the service container as volume mounts. [1]

The custom mqttnio-mosquitto image solved this problem by pre-populating the mosquitto configuration from the mqtt-nio repo such that the container could be run in CI without needing access to the mqtt-nio checkout.

But this leaves the problem of having to manually keep the custom mqttnio-mosquitto image updated with any changes in the repo.

A workaround for containers starting before checkouts is to add an explicit container restart step after the checkout step.

Using this workaround allows CI to use the upstream/canonical eclipse-mosquitto image instead of a custom image. The mosquitto configuration from the repo is thus always up to date and no manual image build/push is required.

[1]: https://github.com/orgs/community/discussions/42127