### PR TITLE
Update swiftformat

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,6 @@ jobs:
     - name: Install Dependencies
       run: |
         brew install mint
-        mint install nicklockwood/swiftformat@0.48.17 --no-link
+        mint install nicklockwood/swiftformat@0.52.10 --no-link
     - name: run script
       run: ./scripts/validate.sh

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,8 +1,8 @@
 # Minimum swiftformat version
---minversion 0.47.4
+--minversion 0.52.0
 
 # Swift version
---swiftversion 5.1
+--swiftversion 5.7
 
 # file options
 --exclude .build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,4 +35,4 @@ docker-compose run test
 
 ### Formatting
 
-We use Nick Lockwood's SwiftFormat for formatting code. PRs will not be accepted if they haven't be formatted. The current version of SwiftFormat we are using is v0.48.17.
+We use Nick Lockwood's SwiftFormat for formatting code. PRs will not be accepted if they haven't be formatted. The current version of SwiftFormat we are using is v0.52.10.

--- a/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClient+async.swift
+++ b/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClient+async.swift
@@ -28,7 +28,7 @@ extension MQTTClient {
     public func shutdown(queue: DispatchQueue = .global()) async throws {
         return try await withUnsafeThrowingContinuation { cont in
             self.shutdown(queue: queue) { error in
-                if let error = error {
+                if let error {
                     cont.resume(throwing: error)
                 } else {
                     cont.resume()

--- a/Sources/MQTTNIO/ChannelHandlers/WebSocketHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/WebSocketHandler.swift
@@ -107,7 +107,7 @@ final class WebSocketHandler: ChannelDuplexHandler {
 
     /// Send ping and setup task to check for pong and send new ping
     private func sendPingAndWait(context: ChannelHandlerContext) {
-        guard context.channel.isActive, let pingInterval = pingInterval else {
+        guard context.channel.isActive, let pingInterval else {
             return
         }
         if self.waitingOnPong {

--- a/Sources/MQTTNIO/MQTTClientV5.swift
+++ b/Sources/MQTTNIO/MQTTClientV5.swift
@@ -187,7 +187,7 @@ extension MQTTClient {
                 if auth.reason == .success {
                     return eventLoop.makeSucceededFuture(auth)
                 }
-                guard let authWorkflow = authWorkflow else { return eventLoop.makeFailedFuture(MQTTError.authWorkflowRequired) }
+                guard let authWorkflow else { return eventLoop.makeFailedFuture(MQTTError.authWorkflowRequired) }
                 return self.client.processAuth(authPacket, authWorkflow: authWorkflow, on: eventLoop)
             }
             .flatMapThrowing { response -> MQTTAuthV5 in

--- a/Sources/MQTTNIO/MQTTInflight.swift
+++ b/Sources/MQTTNIO/MQTTInflight.swift
@@ -24,7 +24,7 @@ struct MQTTInflight {
     /// add packet
     mutating func add(packet: MQTTPacket) {
         self.lock.withLock {
-            packets.append(packet)
+            self.packets.append(packet)
         }
     }
 
@@ -32,14 +32,14 @@ struct MQTTInflight {
     mutating func remove(id: UInt16) {
         self.lock.withLock {
             guard let first = packets.firstIndex(where: { $0.packetId == id }) else { return }
-            packets.remove(at: first)
+            self.packets.remove(at: first)
         }
     }
 
     /// remove all packets
     mutating func clear() {
         self.lock.withLock {
-            packets = []
+            self.packets = []
         }
     }
 

--- a/Sources/MQTTNIO/MQTTListeners.swift
+++ b/Sources/MQTTNIO/MQTTListeners.swift
@@ -28,13 +28,13 @@ final class MQTTListeners<ReturnType> {
 
     func addListener(named name: String, listener: @escaping Listener) {
         self.lock.withLock {
-            listeners[name] = listener
+            self.listeners[name] = listener
         }
     }
 
     func removeListener(named name: String) {
         self.lock.withLock {
-            listeners[name] = nil
+            self.listeners[name] = nil
         }
     }
 

--- a/Sources/MQTTNIO/MQTTPacket.swift
+++ b/Sources/MQTTNIO/MQTTPacket.swift
@@ -13,7 +13,7 @@
 
 import NIOCore
 
-internal enum InternalError: Swift.Error {
+enum InternalError: Swift.Error {
     case incompletePacket
     case notImplemented
 }
@@ -99,7 +99,7 @@ struct MQTTConnectPacket: MQTTPacket {
         byteBuffer.writeInteger(version.versionByte)
         // connect flags
         var flags = self.cleanSession ? ConnectFlags.cleanSession : 0
-        if let will = will {
+        if let will {
             flags |= ConnectFlags.willFlag
             flags |= will.retain ? ConnectFlags.willRetain : 0
             flags |= will.qos.rawValue << ConnectFlags.willQoSShift
@@ -116,17 +116,17 @@ struct MQTTConnectPacket: MQTTPacket {
 
         // payload
         try MQTTSerializer.writeString(self.clientIdentifier, to: &byteBuffer)
-        if let will = will {
+        if let will {
             if version == .v5_0 {
                 try will.properties.write(to: &byteBuffer)
             }
             try MQTTSerializer.writeString(will.topicName, to: &byteBuffer)
             try MQTTSerializer.writeBuffer(will.payload, to: &byteBuffer)
         }
-        if let userName = userName {
+        if let userName {
             try MQTTSerializer.writeString(userName, to: &byteBuffer)
         }
-        if let password = password {
+        if let password {
             try MQTTSerializer.writeString(password, to: &byteBuffer)
         }
     }
@@ -149,7 +149,7 @@ struct MQTTConnectPacket: MQTTPacket {
         // client identifier
         size += self.clientIdentifier.utf8.count + 2
         // will publish
-        if let will = will {
+        if let will {
             // properties
             if version == .v5_0 {
                 let propertiesPacketSize = will.properties.packetSize
@@ -161,11 +161,11 @@ struct MQTTConnectPacket: MQTTPacket {
             size += will.payload.readableBytes + 2
         }
         // user name
-        if let userName = userName {
+        if let userName {
             size += userName.utf8.count + 2
         }
         // password
-        if let password = password {
+        if let password {
             size += password.utf8.count + 2
         }
         return size
@@ -370,7 +370,7 @@ struct MQTTPubAckPacket: MQTTPacket {
     let reason: MQTTReasonCode
     let properties: MQTTProperties
 
-    internal init(
+    init(
         type: MQTTPacketType,
         packetId: UInt16,
         reason: MQTTReasonCode = .success,

--- a/Sources/MQTTNIO/MQTTTask.swift
+++ b/Sources/MQTTNIO/MQTTTask.swift
@@ -23,7 +23,7 @@ final class MQTTTask {
         let promise = eventLoop.makePromise(of: MQTTPacket.self)
         self.promise = promise
         self.checkInbound = checkInbound
-        if let timeout = timeout {
+        if let timeout {
             self.timeoutTask = eventLoop.scheduleTask(in: timeout) {
                 promise.fail(MQTTError.timeout)
             }

--- a/Sources/MQTTNIO/TSTLSConfiguration.swift
+++ b/Sources/MQTTNIO/TSTLSConfiguration.swift
@@ -104,7 +104,7 @@ public struct TSTLSConfiguration {
         public static func pem(_ filename: String) throws -> Self {
             let certificates = try NIOSSLCertificate.fromPEMFile(filename)
             let secCertificates = try certificates.map { certificate -> SecCertificate in
-                guard let certificate = SecCertificateCreateWithData(nil, Data(try certificate.toDERBytes()) as CFData) else { throw TSTLSConfiguration.Error.invalidData }
+                guard let certificate = try SecCertificateCreateWithData(nil, Data(certificate.toDERBytes()) as CFData) else { throw TSTLSConfiguration.Error.invalidData }
                 return certificate
             }
             return .init(certificates: secCertificates)
@@ -254,7 +254,7 @@ extension TSTLSConfiguration {
                     }
                     if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
                         SecTrustEvaluateAsyncWithError(trust, Self.tlsDispatchQueue) { _, result, error in
-                            if let error = error {
+                            if let error {
                                 print("Trust failed: \(error.localizedDescription)")
                             }
                             sec_protocol_verify_complete(result)

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -13,21 +13,22 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-SWIFT_VERSION=5.3
-SWIFT_FORMAT_VERSION=0.48.17
+SWIFT_FORMAT_VERSION=0.52.10
 
 set -eu
-here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-which swiftformat > /dev/null 2>&1 || (echo "swiftformat not installed. You can install it using 'mint install nicklockwood/swiftformat'" ; exit -1)
+command -v swiftformat >/dev/null || {
+  echo "swiftformat not installed. You can install it using 'mint install nicklockwood/swiftformat'"
+  exit 1
+}
 
 printf "=> Checking format... "
 FIRST_OUT="$(git status --porcelain)"
 if [[ -n "${CI-""}" ]]; then
-  printf "(using v$(mint run NickLockwood/SwiftFormat@$SWIFT_FORMAT_VERSION --version)) "
+  printf "(using v%s) " "$(mint run NickLockwood/SwiftFormat@$SWIFT_FORMAT_VERSION --version)"
   mint run NickLockwood/SwiftFormat@$SWIFT_FORMAT_VERSION . > /dev/null 2>&1
 else
-  printf "(using v$(swiftformat --version)) "
+  printf "(using v%s) " "$(swiftformat --version)"
   swiftformat . > /dev/null 2>&1
 fi
 SECOND_OUT="$(git status --porcelain)"


### PR DESCRIPTION
This updates the validation tooling to use `swiftformat` 0.52.10 (was 0.48.17).

I'm assuming there is value in updating tooling from time to time. If not, we can just close this PR.

This updated version of `swiftformat` does drive several formatting changes. The most common is to change, e.g.:

```swift
if let thing = thing {
    ...
}
```

to

```swift
if let thing {
    ...
```

which seems like a nice enough improvement.