### PR TITLE
[Docs/FIX] Fixed web link

### DIFF
--- a/Sources/MQTTNIO/MQTTNIO.docc/mqttnio.md
+++ b/Sources/MQTTNIO/MQTTNIO.docc/mqttnio.md
@@ -59,7 +59,7 @@ try await client.publish(
 )
 ```
 
-MQTTClient supports both Swift concurrency and SwiftNIO `EventLoopFuture`. The above examples use Swift concurrency but there are equivalent versions of these functions that return `EventLoopFuture`s. You can find out more about Swift NIO and `EventLoopFuture` [here](https://apple.github.io/swift-nio/docs/current/NIOCore/Classes/EventLoopFuture.html).
+MQTTClient supports both Swift concurrency and SwiftNIO `EventLoopFuture`. The above examples use Swift concurrency but there are equivalent versions of these functions that return `EventLoopFuture`s. You can find out more about Swift NIO and `EventLoopFuture` [here](https://swiftpackageindex.com/apple/swift-nio/main/documentation/niocore/eventloopfuture).
 
 ## Topics
 


### PR DESCRIPTION
The current web link for `EventLoopFuture` returns 404.
I replaced it to the valid link while referring to [apple/swift-nio](https://github.com/apple/swift-nio) repository.