### PR TITLE
Import FoundationEssentials instead of Foundation when available

### DIFF
--- a/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClient+async.swift
+++ b/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClient+async.swift
@@ -12,8 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(FoundationEssentials)
-import FoundationEssentials
 import Dispatch
+import FoundationEssentials
 #else
 import Foundation
 #endif

--- a/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClient+async.swift
+++ b/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClient+async.swift
@@ -11,7 +11,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+import Dispatch
+#else
 import Foundation
+#endif
 import NIOCore
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)

--- a/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClientV5+async.swift
+++ b/Sources/MQTTNIO/AsyncAwaitSupport/MQTTClientV5+async.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import NIOCore
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)

--- a/Sources/MQTTNIO/MQTTConnection.swift
+++ b/Sources/MQTTNIO/MQTTConnection.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #if canImport(Network)
 import Network
 #endif

--- a/Sources/MQTTNIO/MQTTPacket.swift
+++ b/Sources/MQTTNIO/MQTTPacket.swift
@@ -623,7 +623,7 @@ struct MQTTAuthPacket: MQTTPacket {
 
 /// MQTT incoming packet parameters.
 struct MQTTIncomingPacket: MQTTPacket {
-    var description: String { "Incoming Packet 0x\(String(format: "%x", self.type.rawValue))" }
+    var description: String { "Incoming Packet 0x\(String(self.type.rawValue, radix: 16))" }
 
     /// Type of incoming MQTT packet.
     let type: MQTTPacketType


### PR DESCRIPTION
Removing Foundation dependency on non-Apple platforms allows us to significantly reduce the size of the build product when using the Swift Static Linux SDK.

Hello world docker image depending on mqtt-nio went from 169MB to 85MB.

Related PR in one of the dependencies: https://github.com/apple/swift-nio-transport-services/pull/209