### PR TITLE
Prevent MQTT task timeout double completion

### DIFF
--- a/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTChannelHandler.swift
@@ -169,7 +169,7 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
         self.eventLoop.assertInEventLoop()
         switch self.stateMachine.cancel(requestID: requestID) {
         case .failTask(let cancelledTask):
-            cancelledTask.promise.fail(error)
+            cancelledTask.fail(error)
         case .doNothing:
             break
         }
@@ -370,11 +370,15 @@ final class MQTTChannelHandler: ChannelDuplexHandler {
     ) {
         self.eventLoop.assertInEventLoop()
 
+        let channelHandler = NIOLoopBound(self, eventLoop: self.eventLoop)
         let task = MQTTTask(
             promise: promise,
             requestID: requestID,
             on: self.eventLoop,
             timeout: self.configuration.timeout,
+            onTimeout: {
+                channelHandler.value.cancel(requestID: requestID, error: MQTTError.timeout)
+            },
             checkInbound: checkInbound
         )
 

--- a/Sources/MQTTNIO/ChannelHandlers/MQTTTask.swift
+++ b/Sources/MQTTNIO/ChannelHandlers/MQTTTask.swift
@@ -48,6 +48,7 @@ final class MQTTTask {
         requestID: Int,
         on eventLoop: any EventLoop,
         timeout: TimeAmount?,
+        onTimeout: @escaping @Sendable () -> Void,
         checkInbound: @escaping (any MQTTPacket) throws -> Bool
     ) {
         self.promise = promise
@@ -55,7 +56,7 @@ final class MQTTTask {
         self.requestID = requestID
         if let timeout {
             self.timeoutTask = eventLoop.scheduleTask(in: timeout) {
-                promise.fail(MQTTError.timeout)
+                onTimeout()
             }
         } else {
             self.timeoutTask = nil

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -53,6 +53,25 @@ struct MQTTConnectionTests {
         }
     }
 
+    @Test("A timed-out publish is removed before the connection closes")
+    func publishTimeoutThenConnectionClose() async {
+        await #expect(throws: MQTTError.timeout) {
+            try await withTestMQTTServer(
+                configuration: .init(timeout: .milliseconds(10))
+            ) { connection in
+                try await connection.publish(
+                    to: "testTopic",
+                    payload: ByteBuffer(string: "TestPayload"),
+                    qos: .atLeastOnce,
+                    retain: false
+                )
+            } server: { channel in
+                _ = try await channel.waitForOutboundPacket()
+                await channel.testingEventLoop.advanceTime(by: .milliseconds(10))
+            }
+        }
+    }
+
     @Test
     func testPublishQoS2ClientToServer() async throws {
         try await withTestMQTTServer { connection in


### PR DESCRIPTION
Fixes a race where an MQTT request timeout could complete its promise without removing the request from the channel handler's state machine.

If the connection subsequently closed or failed, the retained task was failed a second time. For async callers this could trigger:

> SWIFT TASK CONTINUATION MISUSE: sendPacket(_:checkInbound:) tried to resume its continuation more than once

## Changes

- Route request timeouts through `MQTTChannelHandler.cancel`.
- Remove the timed-out task from the state machine before failing its promise.
- Use `MQTTTask.fail` for cancellation so its scheduled timeout is cancelled consistently.
- Add a regression test covering a QoS 1 publish that times out immediately before the connection closes.

This ensures that timeout, cancellation, connection failure, and response handling all compete through the same task-ownership path, allowing only one of them to complete the promise.

## Testing

- Added `publishTimeoutThenConnectionClose`.
- Confirmed that the new test reproduces the continuation double-resume crash before the fix.
- Confirmed that the test passes after the fix.
