### PR TITLE
Tracing: propagate trace id via MQTTPublishInfo user properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,13 @@ jobs:
       contents: read
     with:
       swift_image: swift:6.3-noble
+
+  package-traits:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container: swift:6.3
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v7.0.1
+    - name: Build with traits disabled
+      run: swift build --disable-default-traits --build-tests

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,12 @@ let package = Package(
     products: [
         .library(name: "MQTTNIO", targets: ["MQTTNIO"])
     ],
+    traits: [
+        .trait(name: "DistributedTracingSupport"),
+        .default(enabledTraits: ["DistributedTracingSupport"]),
+    ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.100.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.36.0"),
@@ -43,6 +48,7 @@ let package = Package(
             name: "MQTTNIO",
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Tracing", package: "swift-distributed-tracing", condition: .when(traits: ["DistributedTracingSupport"])),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOWebSocket", package: "swift-nio"),
@@ -66,6 +72,7 @@ let package = Package(
             dependencies: [
                 .target(name: "MQTTNIO"),
                 .product(name: "InMemoryLogging", package: "swift-log"),
+                .product(name: "InMemoryTracing", package: "swift-distributed-tracing", condition: .when(traits: ["DistributedTracingSupport"])),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ],
             swiftSettings: defaultSwiftSettings

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ let package = Package(
         .library(name: "MQTTNIO", targets: ["MQTTNIO"])
     ],
     traits: [
-        .trait(name: "DistributedTracingSupport"),
-        .default(enabledTraits: ["DistributedTracingSupport"]),
+        .trait(name: "DistributedTracing"),
+        .default(enabledTraits: ["DistributedTracing"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.4.0"),
@@ -48,7 +48,7 @@ let package = Package(
             name: "MQTTNIO",
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "Tracing", package: "swift-distributed-tracing", condition: .when(traits: ["DistributedTracingSupport"])),
+                .product(name: "Tracing", package: "swift-distributed-tracing", condition: .when(traits: ["DistributedTracing"])),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "NIOWebSocket", package: "swift-nio"),
@@ -72,7 +72,7 @@ let package = Package(
             dependencies: [
                 .target(name: "MQTTNIO"),
                 .product(name: "InMemoryLogging", package: "swift-log"),
-                .product(name: "InMemoryTracing", package: "swift-distributed-tracing", condition: .when(traits: ["DistributedTracingSupport"])),
+                .product(name: "InMemoryTracing", package: "swift-distributed-tracing", condition: .when(traits: ["DistributedTracing"])),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
             ],
             swiftSettings: defaultSwiftSettings

--- a/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
@@ -41,7 +41,7 @@ extension MQTTConnection {
             defer { span?.end() }
 
             if let span, !(span is NoOpTracer.Span) {
-                InstrumentationSystem.instrument.inject(
+                self.connection.tracer?.inject(
                     span.context,
                     into: &info,
                     using: self.connection.configuration.tracing.contextPropagator.injector

--- a/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
@@ -8,6 +8,10 @@
 
 public import NIOCore
 
+#if DistributedTracingSupport
+import Tracing
+#endif
+
 extension MQTTConnection {
     /// Provides implementations of functions that expose MQTT Version 5.0 features.
     public struct V5: Sendable {
@@ -31,7 +35,24 @@ extension MQTTConnection {
             retain: Bool = false,
             properties: MQTTProperties = .init()
         ) async throws -> MQTTAckV5? {
-            let info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: properties)
+            var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: properties)
+            #if DistributedTracingSupport
+            let span = self.connection.tracer?.startSpan("PUBLISH", ofKind: .producer)
+            defer { span?.end() }
+
+            if let span, !(span is NoOpTracer.Span) {
+                InstrumentationSystem.instrument.inject(
+                    span.context,
+                    into: &info,
+                    using: self.connection.configuration.tracing.contextPropagator.injector
+                )
+
+                span.updateAttributes { attributes in
+                    self.connection.applyCommonPublishAttributes(to: &attributes)
+                    attributes[self.connection.configuration.tracing.attributeNames.messagingDestinationName] = topicName
+                }
+            }
+            #endif
             let packetId = await self.connection.updatePacketId()
             let packet = MQTTPublishPacket(publish: info, packetId: packetId)
             return try await self.connection.publish(packet: packet)

--- a/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
@@ -28,6 +28,7 @@ extension MQTTConnection {
         ///     - properties: Properties to attach to publish message.
         ///
         /// - Returns: QoS1 and above return an `MQTTAckV5` which contains a `reason` and `properties`.
+        @inlinable
         public func publish(
             to topicName: String,
             payload: ByteBuffer,
@@ -35,27 +36,7 @@ extension MQTTConnection {
             retain: Bool = false,
             properties: MQTTProperties = .init()
         ) async throws -> MQTTAckV5? {
-            var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: properties)
-            #if DistributedTracingSupport
-            let span = self.connection.tracer?.startSpan("PUBLISH", ofKind: .producer)
-            defer { span?.end() }
-
-            if let span, !(span is NoOpTracer.Span) {
-                self.connection.tracer?.inject(
-                    span.context,
-                    into: &info,
-                    using: self.connection.configuration.tracing.contextPropagator.injector
-                )
-
-                span.updateAttributes { attributes in
-                    self.connection.applyCommonPublishAttributes(to: &attributes)
-                    attributes[self.connection.configuration.tracing.attributeNames.messagingDestinationName] = topicName
-                }
-            }
-            #endif
-            let packetId = await self.connection.updatePacketId()
-            let packet = MQTTPublishPacket(publish: info, packetId: packetId)
-            return try await self.connection.publish(packet: packet)
+            try await self.connection._publish(to: topicName, payload: payload, qos: qos, retain: retain, properties: properties)
         }
 
         /// Re-authenticate with server.

--- a/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection+v5.swift
@@ -8,10 +8,6 @@
 
 public import NIOCore
 
-#if DistributedTracingSupport
-import Tracing
-#endif
-
 extension MQTTConnection {
     /// Provides implementations of functions that expose MQTT Version 5.0 features.
     public struct V5: Sendable {

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -226,7 +226,7 @@ public final actor MQTTConnection: Sendable {
         #if DistributedTracingSupport
         var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: .init())
         if self.configuration.version == .v5_0, let tracer = self.tracer {
-            try await tracer.withSpan("PUBLISH", ofKind: .producer) { span in
+            try await tracer.withSpan("PUBLISH \(topicName)", ofKind: .producer) { span in
                 if !(span is NoOpTracer.Span) {
                     tracer.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
                     span.updateAttributes { attributes in

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -230,7 +230,7 @@ public final actor MQTTConnection: Sendable {
             defer { span?.end() }
 
             if let span, !(span is NoOpTracer.Span) {
-                InstrumentationSystem.instrument.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
+                self.tracer?.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
                 span.updateAttributes { attributes in
                     self.applyCommonPublishAttributes(to: &attributes)
                     attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = topicName

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -337,9 +337,7 @@ public final actor MQTTConnection: Sendable {
     nonisolated func applyCommonSubscribeAttributes(to attributes: inout SpanAttributes) {
         attributes.merge(self.commonSubscribeSpanAttributes)
     }
-
     #endif
-
     /// Connect to MQTT server and return the connection and whether there was a previous session present.
     ///
     /// - Parameters:

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -14,7 +14,7 @@ public import NIOPosix
 import NIOWebSocket
 import Synchronization
 
-#if DistributedTracingSupport
+#if DistributedTracing
 public import Tracing
 #endif
 
@@ -45,7 +45,7 @@ public final actor MQTTConnection: Sendable {
     let configuration: MQTTConnectionConfiguration
     let globalPacketId = Atomic<UInt16>(1)
     let isClosed: Atomic<Bool>
-    #if DistributedTracingSupport
+    #if DistributedTracing
     @usableFromInline
     let tracer: (any Tracer)?
     @usableFromInline
@@ -69,7 +69,7 @@ public final actor MQTTConnection: Sendable {
         self.channelHandler = channelHandler
         self.configuration = configuration
         self.logger = logger
-        #if DistributedTracingSupport
+        #if DistributedTracing
         self.tracer = configuration.tracing.tracer
         self.commonPublishSpanAttributes = Self.createCommonPublishSpanAttributes(address: address, configuration: configuration, channel: channel)
         self.commonSubscribeSpanAttributes = Self.createCommonSubscribeSpanAttributes(
@@ -275,7 +275,7 @@ public final actor MQTTConnection: Sendable {
         }
     }
 
-    #if DistributedTracingSupport
+    #if DistributedTracing
     @usableFromInline
     static func createCommonPublishSpanAttributes(
         address: MQTTServerAddress?,
@@ -293,7 +293,7 @@ public final actor MQTTConnection: Sendable {
         switch address?.value {
         case let .hostname(host, port):
             commonAttributes[configuration.tracing.attributeNames.serverAddress] = host
-            commonAttributes[configuration.tracing.attributeNames.serverPort] = (port == 6379 ? nil : port)
+            commonAttributes[configuration.tracing.attributeNames.serverPort] = (port == 1883 ? nil : port)
         case let .unixDomainSocket(path):
             commonAttributes[configuration.tracing.attributeNames.serverAddress] = path
         case nil:
@@ -324,7 +324,7 @@ public final actor MQTTConnection: Sendable {
         switch address?.value {
         case let .hostname(host, port):
             commonAttributes[configuration.tracing.attributeNames.serverAddress] = host
-            commonAttributes[configuration.tracing.attributeNames.serverPort] = (port == 6379 ? nil : port)
+            commonAttributes[configuration.tracing.attributeNames.serverPort] = (port == 1883 ? nil : port)
         case let .unixDomainSocket(path):
             commonAttributes[configuration.tracing.attributeNames.serverAddress] = path
         case nil:
@@ -997,7 +997,7 @@ public final actor MQTTConnection: Sendable {
         retain: Bool = false,
         properties: MQTTProperties
     ) async throws -> MQTTAckV5? {
-        #if DistributedTracingSupport
+        #if DistributedTracing
         var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: properties)
         if self.configuration.version == .v5_0, let tracer = self.tracer {
             return try await tracer.withSpan("publish \(topicName)", ofKind: .producer) { span in

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -1000,7 +1000,7 @@ public final actor MQTTConnection: Sendable {
         #if DistributedTracingSupport
         var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: properties)
         if self.configuration.version == .v5_0, let tracer = self.tracer {
-            return try await tracer.withSpan("PUBLISH \(topicName)", ofKind: .producer) { span in
+            return try await tracer.withSpan("publish \(topicName)", ofKind: .producer) { span in
                 if !(span is NoOpTracer.Span) {
                     tracer.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
                     span.updateAttributes { attributes in

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -225,20 +225,19 @@ public final actor MQTTConnection: Sendable {
     ) async throws {
         #if DistributedTracingSupport
         var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: .init())
-        if self.configuration.version == .v5_0 {
-            let span = self.tracer?.startSpan("PUBLISH", ofKind: .producer)
-            defer { span?.end() }
-
-            if let span, !(span is NoOpTracer.Span) {
-                self.tracer?.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
-                span.updateAttributes { attributes in
-                    self.applyCommonPublishAttributes(to: &attributes)
-                    attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = topicName
+        if self.configuration.version == .v5_0, let tracer = self.tracer {
+            try await withSpan("PUBLISH", ofKind: .producer) { span in
+                if !(span is NoOpTracer.Span) {
+                    tracer.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
+                    span.updateAttributes { attributes in
+                        self.applyCommonPublishAttributes(to: &attributes)
+                        attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = topicName
+                    }
                 }
+                let packetId = self.updatePacketId()
+                let packet = MQTTPublishPacket(publish: info, packetId: packetId)
+                _ = try await self.publish(packet: packet)
             }
-            let packetId = self.updatePacketId()
-            let packet = MQTTPublishPacket(publish: info, packetId: packetId)
-            _ = try await self.publish(packet: packet)
         } else {
             let packetId = self.updatePacketId()
             let packet = MQTTPublishPacket(publish: info, packetId: packetId)

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -14,6 +14,10 @@ public import NIOPosix
 import NIOWebSocket
 import Synchronization
 
+#if DistributedTracingSupport
+public import Tracing
+#endif
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -41,6 +45,14 @@ public final actor MQTTConnection: Sendable {
     let configuration: MQTTConnectionConfiguration
     let globalPacketId = Atomic<UInt16>(1)
     let isClosed: Atomic<Bool>
+    #if DistributedTracingSupport
+    @usableFromInline
+    let tracer: (any Tracer)?
+    @usableFromInline
+    let commonPublishSpanAttributes: SpanAttributes
+    @usableFromInline
+    let commonSubscribeSpanAttributes: SpanAttributes
+    #endif
 
     var connectionParameters = ConnectionParameters()
 
@@ -57,6 +69,15 @@ public final actor MQTTConnection: Sendable {
         self.channelHandler = channelHandler
         self.configuration = configuration
         self.logger = logger
+        #if DistributedTracingSupport
+        self.tracer = configuration.tracing.tracer
+        self.commonPublishSpanAttributes = Self.createCommonPublishSpanAttributes(address: address, configuration: configuration, channel: channel)
+        self.commonSubscribeSpanAttributes = Self.createCommonSubscribeSpanAttributes(
+            address: address,
+            configuration: configuration,
+            channel: channel
+        )
+        #endif
         self.isClosed = .init(false)
     }
 
@@ -202,10 +223,33 @@ public final actor MQTTConnection: Sendable {
         qos: MQTTQoS,
         retain: Bool = false,
     ) async throws {
+        #if DistributedTracingSupport
+        var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: .init())
+        if self.configuration.version == .v5_0 {
+            let span = self.tracer?.startSpan("PUBLISH", ofKind: .producer)
+            defer { span?.end() }
+
+            if let span, !(span is NoOpTracer.Span) {
+                InstrumentationSystem.instrument.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
+                span.updateAttributes { attributes in
+                    self.applyCommonPublishAttributes(to: &attributes)
+                    attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = topicName
+                }
+            }
+            let packetId = self.updatePacketId()
+            let packet = MQTTPublishPacket(publish: info, packetId: packetId)
+            _ = try await self.publish(packet: packet)
+        } else {
+            let packetId = self.updatePacketId()
+            let packet = MQTTPublishPacket(publish: info, packetId: packetId)
+            _ = try await self.publish(packet: packet)
+        }
+        #else
         let info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: .init())
         let packetId = self.updatePacketId()
         let packet = MQTTPublishPacket(publish: info, packetId: packetId)
         _ = try await self.publish(packet: packet)
+        #endif
     }
 
     /// Ping the server to test if it is still alive and to tell it you are alive.
@@ -255,6 +299,71 @@ public final actor MQTTConnection: Sendable {
             }
         }
     }
+
+    #if DistributedTracingSupport
+    @usableFromInline
+    static func createCommonPublishSpanAttributes(
+        address: MQTTServerAddress?,
+        configuration: MQTTConnectionConfiguration,
+        channel: any Channel
+    ) -> SpanAttributes {
+        var commonAttributes: SpanAttributes = [
+            configuration.tracing.attributeNames.messagingSystemName: .string(configuration.tracing.attributeValues.messagingSystem),
+            configuration.tracing.attributeNames.messagingOperationName: "publish",
+        ]
+        if let remoteAddress = channel.remoteAddress {
+            commonAttributes[configuration.tracing.attributeNames.networkPeerAddress] = remoteAddress.ipAddress
+            commonAttributes[configuration.tracing.attributeNames.networkPeerPort] = remoteAddress.port
+        }
+        switch address?.value {
+        case let .hostname(host, port):
+            commonAttributes[configuration.tracing.attributeNames.serverAddress] = host
+            commonAttributes[configuration.tracing.attributeNames.serverPort] = (port == 6379 ? nil : port)
+        case let .unixDomainSocket(path):
+            commonAttributes[configuration.tracing.attributeNames.serverAddress] = path
+        case nil:
+            break
+        }
+        return commonAttributes
+    }
+
+    @usableFromInline
+    nonisolated func applyCommonPublishAttributes(to attributes: inout SpanAttributes) {
+        attributes.merge(self.commonPublishSpanAttributes)
+    }
+
+    @usableFromInline
+    static func createCommonSubscribeSpanAttributes(
+        address: MQTTServerAddress?,
+        configuration: MQTTConnectionConfiguration,
+        channel: any Channel
+    ) -> SpanAttributes {
+        var commonAttributes: SpanAttributes = [
+            configuration.tracing.attributeNames.messagingSystemName: .string(configuration.tracing.attributeValues.messagingSystem),
+            configuration.tracing.attributeNames.messagingOperationName: "subscribe",
+        ]
+        if let remoteAddress = channel.remoteAddress {
+            commonAttributes[configuration.tracing.attributeNames.networkPeerAddress] = remoteAddress.ipAddress
+            commonAttributes[configuration.tracing.attributeNames.networkPeerPort] = remoteAddress.port
+        }
+        switch address?.value {
+        case let .hostname(host, port):
+            commonAttributes[configuration.tracing.attributeNames.serverAddress] = host
+            commonAttributes[configuration.tracing.attributeNames.serverPort] = (port == 6379 ? nil : port)
+        case let .unixDomainSocket(path):
+            commonAttributes[configuration.tracing.attributeNames.serverAddress] = path
+        case nil:
+            break
+        }
+        return commonAttributes
+    }
+
+    @usableFromInline
+    nonisolated func applyCommonSubscribeAttributes(to attributes: inout SpanAttributes) {
+        attributes.merge(self.commonSubscribeSpanAttributes)
+    }
+
+    #endif
 
     /// Connect to MQTT server and return the connection and whether there was a previous session present.
     ///

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -217,38 +217,14 @@ public final actor MQTTConnection: Sendable {
     ///     - payload: Message payload.
     ///     - qos: Quality of Service for message.
     ///     - retain: Whether this is a retained message.
+    @inlinable
     public func publish(
         to topicName: String,
         payload: ByteBuffer,
         qos: MQTTQoS,
         retain: Bool = false,
     ) async throws {
-        #if DistributedTracingSupport
-        var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: .init())
-        if self.configuration.version == .v5_0, let tracer = self.tracer {
-            try await tracer.withSpan("PUBLISH \(topicName)", ofKind: .producer) { span in
-                if !(span is NoOpTracer.Span) {
-                    tracer.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
-                    span.updateAttributes { attributes in
-                        self.applyCommonPublishAttributes(to: &attributes)
-                        attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = topicName
-                    }
-                }
-                let packetId = self.updatePacketId()
-                let packet = MQTTPublishPacket(publish: info, packetId: packetId)
-                _ = try await self.publish(packet: packet)
-            }
-        } else {
-            let packetId = self.updatePacketId()
-            let packet = MQTTPublishPacket(publish: info, packetId: packetId)
-            _ = try await self.publish(packet: packet)
-        }
-        #else
-        let info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: .init())
-        let packetId = self.updatePacketId()
-        let packet = MQTTPublishPacket(publish: info, packetId: packetId)
-        _ = try await self.publish(packet: packet)
-        #endif
+        _ = try await _publish(to: topicName, payload: payload, qos: qos, retain: retain, properties: .init())
     }
 
     /// Ping the server to test if it is still alive and to tell it you are alive.
@@ -1010,6 +986,43 @@ public final actor MQTTConnection: Sendable {
         default:
             throw MQTTError.unexpectedPacket
         }
+    }
+
+    /// Publish message to topic
+    @usableFromInline
+    func _publish(
+        to topicName: String,
+        payload: ByteBuffer,
+        qos: MQTTQoS,
+        retain: Bool = false,
+        properties: MQTTProperties
+    ) async throws -> MQTTAckV5? {
+        #if DistributedTracingSupport
+        var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: properties)
+        if self.configuration.version == .v5_0, let tracer = self.tracer {
+            return try await tracer.withSpan("PUBLISH \(topicName)", ofKind: .producer) { span in
+                if !(span is NoOpTracer.Span) {
+                    tracer.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
+                    span.updateAttributes { attributes in
+                        self.applyCommonPublishAttributes(to: &attributes)
+                        attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = topicName
+                    }
+                }
+                let packetId = self.updatePacketId()
+                let packet = MQTTPublishPacket(publish: info, packetId: packetId)
+                return try await self.publish(packet: packet)
+            }
+        } else {
+            let packetId = self.updatePacketId()
+            let packet = MQTTPublishPacket(publish: info, packetId: packetId)
+            return try await self.publish(packet: packet)
+        }
+        #else
+        let info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: properties)
+        let packetId = self.updatePacketId()
+        let packet = MQTTPublishPacket(publish: info, packetId: packetId)
+        return try await self.publish(packet: packet)
+        #endif
     }
 
     /// Publish message to topic

--- a/Sources/MQTTNIO/Connection/MQTTConnection.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnection.swift
@@ -226,7 +226,7 @@ public final actor MQTTConnection: Sendable {
         #if DistributedTracingSupport
         var info = MQTTPublishInfo(qos: qos, retain: retain, dup: false, topicName: topicName, payload: payload, properties: .init())
         if self.configuration.version == .v5_0, let tracer = self.tracer {
-            try await withSpan("PUBLISH", ofKind: .producer) { span in
+            try await tracer.withSpan("PUBLISH", ofKind: .producer) { span in
                 if !(span is NoOpTracer.Span) {
                     tracer.inject(span.context, into: &info, using: self.configuration.tracing.contextPropagator.injector)
                     span.updateAttributes { attributes in

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration.swift
@@ -9,7 +9,7 @@
 public import HTTPTypes
 public import NIOCore
 
-#if DistributedTracingSupport
+#if DistributedTracing
 import Tracing
 #endif
 
@@ -259,7 +259,7 @@ public struct MQTTConnectionConfiguration: Sendable {
     /// Transport to use for the connection and its associated configuration.
     public var transport: Transport
 
-    #if DistributedTracingSupport
+    #if DistributedTracing
     /// The distributed tracing configuration to use for this connection.
     /// Defaults to using the globally bootstrapped tracer with OpenTelemetry semantic conventions.
     public var tracing: MQTTTracingConfiguration = .init()

--- a/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration.swift
+++ b/Sources/MQTTNIO/Connection/MQTTConnectionConfiguration.swift
@@ -9,6 +9,10 @@
 public import HTTPTypes
 public import NIOCore
 
+#if DistributedTracingSupport
+import Tracing
+#endif
+
 #if os(macOS) || os(Linux) || os(Android)
 public import NIOSSL
 #endif
@@ -254,6 +258,12 @@ public struct MQTTConnectionConfiguration: Sendable {
     public var password: String?
     /// Transport to use for the connection and its associated configuration.
     public var transport: Transport
+
+    #if DistributedTracingSupport
+    /// The distributed tracing configuration to use for this connection.
+    /// Defaults to using the globally bootstrapped tracer with OpenTelemetry semantic conventions.
+    public var tracing: MQTTTracingConfiguration = .init()
+    #endif
 
     /// Creates a new MQTT connection configuration.
     ///

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#if DistributedTracingSupport
+#if DistributedTracing
 
 public import Tracing
 
@@ -57,24 +57,24 @@ extension MQTTContextPropagator where Self == UserPropertiesPropagator {
 public struct MQTTTracingConfiguration: Sendable {
     /// The tracer to use, or `nil` to disable tracing.
     /// Defaults to the globally bootstrapped tracer.
-    public var tracer: (any Tracer)? = InstrumentationSystem.tracer
+    public var tracer: (any Tracer)?
 
     /// Tracing context propagator
-    public var contextPropagator: any MQTTContextPropagator = .userProperties
+    public var contextPropagator: any MQTTContextPropagator
 
     /// Controls how publish and subscribe spans are linked. By default the subscribe
     /// span is linked to the publish context and is a child of current span.
     /// If this is set to true the subscribe span is set to be a child of the publish
     /// context and a link to the current span is stored.
-    public var createChildConsumerSpans: Bool = false
+    public var createChildConsumerSpans: Bool
 
-    /// The attribute names used in spans created by Valkey. Defaults to OpenTelemetry semantics.
+    /// The attribute names used in spans created by MQTTNIO. Defaults to OpenTelemetry semantics.
     public var attributeNames: AttributeNames = .init()
 
-    /// The static attribute values used in spans created by Valkey.
+    /// The static attribute values used in spans created by MQTTNIO.
     public var attributeValues: AttributeValues = .init()
 
-    /// Attribute names used in spans created by Valkey.
+    /// Attribute names used in spans created by MQTTNIO.
     public struct AttributeNames: Sendable {
         public var messagingOperationName: String = "messaging.operation.name"
         public var messagingSystemName: String = "messaging.system"
@@ -85,9 +85,24 @@ public struct MQTTTracingConfiguration: Sendable {
         public var serverPort: String = "server.port"
     }
 
-    /// Static attribute values used in spans created by Valkey.
+    /// Static attribute values used in spans created by MQTTNIO.
     public struct AttributeValues: Sendable {
         public var messagingSystem: String = "mqtt"
+    }
+
+    /// Initialize a MQTTTracingConfiguration
+    /// - Parameters:
+    ///   - tracer: Tracer to use
+    ///   - contextPropagator: Defines how trace context is propagated
+    ///   - createChildConsumerSpans: Controls how publish and subscribe spans are linked
+    public init(
+        tracer: (any Tracer)? = InstrumentationSystem.tracer,
+        contextPropagator: any MQTTContextPropagator = .userProperties,
+        createChildConsumerSpans: Bool = false
+    ) {
+        self.tracer = tracer
+        self.contextPropagator = contextPropagator
+        self.createChildConsumerSpans = createChildConsumerSpans
     }
 }
 

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -94,7 +94,7 @@ extension MQTTConnection {
     ///   - operation:
     public func withMessageSpan<Value>(
         _ publishInfo: MQTTPublishInfo,
-        _ operation: sending ((any Span)?) async throws -> Value
+        _ operation: ((any Span)?) async throws -> Value
     ) async throws -> Value {
         if let tracer = self.configuration.tracing.tracer {
             var serviceContext = ServiceContext.current ?? ServiceContext.topLevel

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -92,7 +92,7 @@ extension MQTTConnection {
     /// - Parameters:
     ///   - publishInfo:
     ///   - operation:
-    func withMessageSpan<Value>(
+    public func withMessageSpan<Value>(
         _ publishInfo: MQTTPublishInfo,
         _ operation: sending ((any Span)?) async throws -> Value
     ) async throws -> Value {

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -1,0 +1,105 @@
+//
+// This source file is part of the MQTTNIO project
+// Copyright (c) 2020-2026 the MQTTNIO authors
+//
+// See LICENSE for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#if DistributedTracingSupport
+
+public import Tracing
+
+/// Tracing context injector that injects into a ``MQTTPublishInfo``.
+public protocol MQTTPublishInfoInjector: Injector where Carrier == MQTTPublishInfo {
+}
+/// Tracing context extractor that extracts from a ``MQTTPublishInfo``.
+public protocol MQTTPublishInfoExtractor: Extractor where Carrier == MQTTPublishInfo {
+}
+/// Tracing context propagator that defines how the tracing context is propagated via
+/// a ``MQTTPublishInfo``.
+public protocol MQTTContextPropagator: Sendable {
+    associatedtype Injector: MQTTPublishInfoInjector
+    associatedtype Extractor: MQTTPublishInfoExtractor
+
+    var injector: Injector { get }
+    var extractor: Extractor { get }
+}
+
+/// Tracing context propagator that propagates the tracing context via the publish info
+/// user properties
+public struct UserPropertiesPropagator: MQTTContextPropagator {
+    public struct Injector: MQTTPublishInfoInjector {
+        public func inject(_ value: String, forKey key: String, into carrier: inout MQTTPublishInfo) {
+            carrier.properties.append(.userProperty(key, value))
+        }
+    }
+    public struct Extractor: MQTTPublishInfoExtractor {
+        public func extract(key: String, from carrier: MQTTPublishInfo) -> String? {
+            for property in carrier.properties {
+                if case .userProperty(key, let propertyValue) = property {
+                    return propertyValue
+                }
+            }
+            return nil
+        }
+    }
+
+    public var injector: Injector { .init() }
+    public var extractor: Extractor { .init() }
+}
+
+extension MQTTContextPropagator where Self == UserPropertiesPropagator {
+    public static var userProperties: Self { UserPropertiesPropagator() }
+}
+
+/// A configuration object that defines distributed tracing behavior of a MQTT client.
+public struct MQTTTracingConfiguration: Sendable {
+    /// The tracer to use, or `nil` to disable tracing.
+    /// Defaults to the globally bootstrapped tracer.
+    public var tracer: (any Tracer)? = InstrumentationSystem.tracer
+
+    /// Tracing context propagator
+    public var contextPropagator: any MQTTContextPropagator = .userProperties
+
+    /// The attribute names used in spans created by Valkey. Defaults to OpenTelemetry semantics.
+    public var attributeNames: AttributeNames = .init()
+
+    /// The static attribute values used in spans created by Valkey.
+    public var attributeValues: AttributeValues = .init()
+
+    /// Attribute names used in spans created by Valkey.
+    public struct AttributeNames: Sendable {
+        public var messagingOperationName: String = "messaging.operation.name"
+        public var messagingSystemName: String = "messaging.system"
+        public var messagingDestinationName: String = "messaging.destination.name"
+        public var networkPeerAddress: String = "network.peer.address"
+        public var networkPeerPort: String = "network.peer.port"
+        public var serverAddress: String = "server.address"
+        public var serverPort: String = "server.port"
+    }
+
+    /// Static attribute values used in spans created by Valkey.
+    public struct AttributeValues: Sendable {
+        public var messagingSystem: String = "mqtt"
+    }
+}
+
+extension MQTTConnection {
+    func withMessageSpan<Value>(
+        _ publishInfo: MQTTPublishInfo,
+        _ operation: (any Span) async throws -> Value
+    ) async throws -> Value {
+        var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
+        InstrumentationSystem.instrument.extract(publishInfo, into: &serviceContext, using: self.configuration.tracing.contextPropagator.extractor)
+        return try await Tracing.withSpan("SUBSCRIBE", context: serviceContext, ofKind: .client) { span in
+            span.updateAttributes { attributes in
+                self.applyCommonSubscribeAttributes(to: &attributes)
+                attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = publishInfo.topicName
+            }
+            return try await operation(span)
+        }
+    }
+}
+
+#endif

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -88,7 +88,7 @@ public struct MQTTTracingConfiguration: Sendable {
 extension MQTTConnection {
     func withMessageSpan<Value>(
         _ publishInfo: MQTTPublishInfo,
-        _ operation: (any Span) async throws -> Value
+        _ operation: sending (any Span) async throws -> Value
     ) async throws -> Value {
         var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
         self.tracer?.extract(publishInfo, into: &serviceContext, using: self.configuration.tracing.contextPropagator.extractor)

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -91,7 +91,7 @@ extension MQTTConnection {
         _ operation: (any Span) async throws -> Value
     ) async throws -> Value {
         var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
-        InstrumentationSystem.instrument.extract(publishInfo, into: &serviceContext, using: self.configuration.tracing.contextPropagator.extractor)
+        self.tracer?.extract(publishInfo, into: &serviceContext, using: self.configuration.tracing.contextPropagator.extractor)
         return try await Tracing.withSpan("SUBSCRIBE", context: serviceContext, ofKind: .client) { span in
             span.updateAttributes { attributes in
                 self.applyCommonSubscribeAttributes(to: &attributes)

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -113,8 +113,9 @@ extension MQTTConnection {
                 spanKind = .consumer
             } else {
                 spanContext = ServiceContext.current ?? ServiceContext.topLevel
-                linkContext = ServiceContext.topLevel
-                tracer.extract(publishInfo, into: &spanContext, using: self.configuration.tracing.contextPropagator.extractor)
+                var topLevel = ServiceContext.topLevel
+                tracer.extract(publishInfo, into: &topLevel, using: self.configuration.tracing.contextPropagator.extractor)
+                linkContext = topLevel
                 spanKind = .client
             }
             return try await tracer.withSpan("subscribe \(publishInfo.topicName)", context: spanContext, ofKind: spanKind) { span in

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -92,14 +92,14 @@ extension MQTTConnection {
     /// - Parameters:
     ///   - publishInfo:
     ///   - operation:
-    public func withMessageSpan<Value>(
+    public nonisolated func withMessageSpan<Value>(
         _ publishInfo: MQTTPublishInfo,
         _ operation: ((any Span)?) async throws -> Value
     ) async throws -> Value {
         if let tracer = self.configuration.tracing.tracer {
             var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
             tracer.extract(publishInfo, into: &serviceContext, using: self.configuration.tracing.contextPropagator.extractor)
-            return try await tracer.withSpan("SUBSCRIBE", context: serviceContext, ofKind: .consumer) { span in
+            return try await tracer.withSpan("SUBSCRIBE \(publishInfo.topicName)", context: serviceContext, ofKind: .consumer) { span in
                 span.updateAttributes { attributes in
                     self.applyCommonSubscribeAttributes(to: &attributes)
                     attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = publishInfo.topicName

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -86,18 +86,28 @@ public struct MQTTTracingConfiguration: Sendable {
 }
 
 extension MQTTConnection {
+    /// Start a new span with trace ID from publish info and end the span when the
+    /// operation completes.
+    ///
+    /// - Parameters:
+    ///   - publishInfo:
+    ///   - operation:
     func withMessageSpan<Value>(
         _ publishInfo: MQTTPublishInfo,
-        _ operation: sending (any Span) async throws -> Value
+        _ operation: sending ((any Span)?) async throws -> Value
     ) async throws -> Value {
-        var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
-        self.tracer?.extract(publishInfo, into: &serviceContext, using: self.configuration.tracing.contextPropagator.extractor)
-        return try await Tracing.withSpan("SUBSCRIBE", context: serviceContext, ofKind: .client) { span in
-            span.updateAttributes { attributes in
-                self.applyCommonSubscribeAttributes(to: &attributes)
-                attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = publishInfo.topicName
+        if let tracer = self.configuration.tracing.tracer {
+            var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
+            tracer.extract(publishInfo, into: &serviceContext, using: self.configuration.tracing.contextPropagator.extractor)
+            return try await tracer.withSpan("SUBSCRIBE", context: serviceContext, ofKind: .consumer) { span in
+                span.updateAttributes { attributes in
+                    self.applyCommonSubscribeAttributes(to: &attributes)
+                    attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = publishInfo.topicName
+                }
+                return try await operation(span)
             }
-            return try await operation(span)
+        } else {
+            return try await operation(nil)
         }
     }
 }

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -62,6 +62,12 @@ public struct MQTTTracingConfiguration: Sendable {
     /// Tracing context propagator
     public var contextPropagator: any MQTTContextPropagator = .userProperties
 
+    /// Controls how publish and subscribe spans are linked. By default the subscribe
+    /// span is linked to the publish context and is a child of current span.
+    /// If this is set to true the subscribe span is set to be a child of the publish
+    /// context and a link to the current span is stored.
+    public var createChildConsumerSpans: Bool = false
+
     /// The attribute names used in spans created by Valkey. Defaults to OpenTelemetry semantics.
     public var attributeNames: AttributeNames = .init()
 
@@ -97,12 +103,27 @@ extension MQTTConnection {
         _ operation: ((any Span)?) async throws -> Value
     ) async throws -> Value {
         if let tracer = self.configuration.tracing.tracer {
-            var serviceContext = ServiceContext.current ?? ServiceContext.topLevel
-            tracer.extract(publishInfo, into: &serviceContext, using: self.configuration.tracing.contextPropagator.extractor)
-            return try await tracer.withSpan("SUBSCRIBE \(publishInfo.topicName)", context: serviceContext, ofKind: .consumer) { span in
+            var spanContext: ServiceContext
+            var linkContext: ServiceContext?
+            let spanKind: SpanKind
+            if self.configuration.tracing.createChildConsumerSpans {
+                spanContext = ServiceContext.topLevel
+                tracer.extract(publishInfo, into: &spanContext, using: self.configuration.tracing.contextPropagator.extractor)
+                linkContext = ServiceContext.current
+                spanKind = .consumer
+            } else {
+                spanContext = ServiceContext.current ?? ServiceContext.topLevel
+                linkContext = ServiceContext.topLevel
+                tracer.extract(publishInfo, into: &spanContext, using: self.configuration.tracing.contextPropagator.extractor)
+                spanKind = .client
+            }
+            return try await tracer.withSpan("subscribe \(publishInfo.topicName)", context: spanContext, ofKind: spanKind) { span in
                 span.updateAttributes { attributes in
                     self.applyCommonSubscribeAttributes(to: &attributes)
                     attributes[self.configuration.tracing.attributeNames.messagingDestinationName] = publishInfo.topicName
+                }
+                if let linkContext {
+                    span.addLink(.init(context: linkContext, attributes: [:]))
                 }
                 return try await operation(span)
             }

--- a/Sources/MQTTNIO/Tracing.swift
+++ b/Sources/MQTTNIO/Tracing.swift
@@ -62,12 +62,6 @@ public struct MQTTTracingConfiguration: Sendable {
     /// Tracing context propagator
     public var contextPropagator: any MQTTContextPropagator
 
-    /// Controls how publish and subscribe spans are linked. By default the subscribe
-    /// span is linked to the publish context and is a child of current span.
-    /// If this is set to true the subscribe span is set to be a child of the publish
-    /// context and a link to the current span is stored.
-    public var createChildConsumerSpans: Bool
-
     /// The attribute names used in spans created by MQTTNIO. Defaults to OpenTelemetry semantics.
     public var attributeNames: AttributeNames = .init()
 
@@ -97,12 +91,10 @@ public struct MQTTTracingConfiguration: Sendable {
     ///   - createChildConsumerSpans: Controls how publish and subscribe spans are linked
     public init(
         tracer: (any Tracer)? = InstrumentationSystem.tracer,
-        contextPropagator: any MQTTContextPropagator = .userProperties,
-        createChildConsumerSpans: Bool = false
+        contextPropagator: any MQTTContextPropagator = .userProperties
     ) {
         self.tracer = tracer
         self.contextPropagator = contextPropagator
-        self.createChildConsumerSpans = createChildConsumerSpans
     }
 }
 
@@ -110,18 +102,24 @@ extension MQTTConnection {
     /// Start a new span with trace ID from publish info and end the span when the
     /// operation completes.
     ///
+    /// By default the subscribe span is linked to the publish context and is a child of
+    /// current span. If `createChildSpans` is set to true the subscribe span is set to be
+    /// a child of the publish context and a link to the current span is stored.
+    ///
     /// - Parameters:
-    ///   - publishInfo:
-    ///   - operation:
+    ///   - publishInfo: PublishInfo to create span for
+    ///   - createChildSpan: Should span be linked to publish context or set as a child
+    ///   - operation: Operation to perform with generated span
     public nonisolated func withMessageSpan<Value>(
         _ publishInfo: MQTTPublishInfo,
+        createChildSpan: Bool = false,
         _ operation: ((any Span)?) async throws -> Value
     ) async throws -> Value {
         if let tracer = self.configuration.tracing.tracer {
             var spanContext: ServiceContext
             var linkContext: ServiceContext?
             let spanKind: SpanKind
-            if self.configuration.tracing.createChildConsumerSpans {
+            if createChildSpan {
                 spanContext = ServiceContext.topLevel
                 tracer.extract(publishInfo, into: &spanContext, using: self.configuration.tracing.contextPropagator.extractor)
                 linkContext = ServiceContext.current

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -683,7 +683,7 @@ struct IntegrationV5Tests {
 
         #expect(tracer1.finishedSpans.count == 2)
         let traceID = tracer1.finishedSpans[0].traceID
-        #expect(tracer1.finishedSpans[0].operationName == "PUBLISH traceContextPropagation")
+        #expect(tracer1.finishedSpans[0].operationName == "publish traceContextPropagation")
         #expect(tracer1.finishedSpans[0].kind == .producer)
         expectSpanAttributesIncludes(
             tracer1.finishedSpans[0].attributes,
@@ -692,7 +692,6 @@ struct IntegrationV5Tests {
                 "messaging.system": "mqtt",
                 "messaging.destination.name": "traceContextPropagation",
                 "server.address": .string(Self.hostname),
-                "server.port": 1883,
             ]
         )
         #expect(tracer2.finishedSpans.count == 1)

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -14,7 +14,7 @@ import Testing
 
 @testable import MQTTNIO
 
-#if DistributedTracingSupport
+#if DistributedTracing
 import InMemoryTracing
 import Tracing
 #endif
@@ -625,7 +625,7 @@ struct IntegrationV5Tests {
         }
     }
 
-    #if DistributedTracingSupport
+    #if DistributedTracing
 
     @Test
     func traceContextPropagation() async throws {

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -632,9 +632,11 @@ struct IntegrationV5Tests {
         let tracer1 = InMemoryTracer()
         var config1 = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
         config1.tracing.tracer = tracer1
+        config1.tracing.createChildConsumerSpans = true
         let tracer2 = InMemoryTracer()
         var config2 = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
         config2.tracing.tracer = tracer2
+        config2.tracing.createChildConsumerSpans = true
 
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
@@ -703,7 +705,6 @@ struct IntegrationV5Tests {
                 "messaging.system": "mqtt",
                 "messaging.destination.name": "traceContextPropagation",
                 "server.address": .string(Self.hostname),
-                "server.port": 1883,
             ]
         )
     }

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -629,24 +629,27 @@ struct IntegrationV5Tests {
 
     @Test
     func traceContextPropagation() async throws {
-        let tracer = InMemoryTracer()
-        var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
-        config.tracing.tracer = tracer
+        let tracer1 = InMemoryTracer()
+        var config1 = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
+        config1.tracing.tracer = tracer1
+        let tracer2 = InMemoryTracer()
+        var config2 = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
+        config2.tracing.tracer = tracer2
 
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
-            configuration: config,
+            configuration: config1,
             identifier: "traceContextPropagationPublish"
         ) { connection in
             try await MQTTConnection.withConnection(
                 address: .hostname(Self.hostname),
-                configuration: config,
+                configuration: config2,
                 identifier: "traceContextPropagationSubscribe"
             ) { connection2 in
                 try await withThrowingTaskGroup(of: String.self) { group in
                     group.addTask {
                         try await Task.sleep(for: .seconds(1))
-                        return try await tracer.withSpan("test)") { span in
+                        return try await tracer1.withSpan("test)") { span in
                             _ = try await connection.v5.publish(
                                 to: "traceContextPropagation",
                                 payload: ByteBuffer(string: "test"),
@@ -661,7 +664,7 @@ struct IntegrationV5Tests {
                             subscription in
                             var subscriptionIterator = subscription.makeAsyncIterator()
                             if let message = try await subscriptionIterator.next() {
-                                return try await connection.withMessageSpan(message) { span in
+                                return try await connection2.withMessageSpan(message) { span in
                                     span?.context.inMemorySpanContext?.traceID ?? "No subscription trace id"
                                 }
                             }
@@ -676,12 +679,12 @@ struct IntegrationV5Tests {
             }
         }
 
-        #expect(tracer.finishedSpans.count == 3)
-        let traceID = tracer.finishedSpans[0].traceID
-        #expect(tracer.finishedSpans[0].operationName == "PUBLISH")
-        #expect(tracer.finishedSpans[0].kind == .producer)
+        #expect(tracer1.finishedSpans.count == 2)
+        let traceID = tracer1.finishedSpans[0].traceID
+        #expect(tracer1.finishedSpans[0].operationName == "PUBLISH traceContextPropagation")
+        #expect(tracer1.finishedSpans[0].kind == .producer)
         expectSpanAttributesIncludes(
-            tracer.finishedSpans[0].attributes,
+            tracer1.finishedSpans[0].attributes,
             [
                 "messaging.operation.name": "publish",
                 "messaging.system": "mqtt",
@@ -690,10 +693,11 @@ struct IntegrationV5Tests {
                 "server.port": 1883,
             ]
         )
-        #expect(tracer.finishedSpans[2].traceID == traceID)
-        #expect(tracer.finishedSpans[2].kind == .consumer)
+        #expect(tracer2.finishedSpans.count == 1)
+        #expect(tracer2.finishedSpans[0].traceID == traceID)
+        #expect(tracer2.finishedSpans[0].kind == .consumer)
         expectSpanAttributesIncludes(
-            tracer.finishedSpans[2].attributes,
+            tracer2.finishedSpans[0].attributes,
             [
                 "messaging.operation.name": "subscribe",
                 "messaging.system": "mqtt",

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -450,7 +450,7 @@ struct IntegrationV5Tests {
         }
     }
 
-    @Test("Subscribe to All Topics", .disabled(if: ProcessInfo.processInfo.environment["CI"] != nil))
+    @Test("Subscribe to All Topics V5", .disabled(if: ProcessInfo.processInfo.environment["CI"] != nil))
     func subscribeAll() async throws {
         try await MQTTConnection.withConnection(
             address: .hostname("broker.hivemq.com"),

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -630,7 +630,6 @@ struct IntegrationV5Tests {
     @Test
     func traceContextPropagation() async throws {
         let tracer = InMemoryTracer()
-        InstrumentationSystem.bootstrap(tracer)
         var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
         config.tracing.tracer = tracer
 
@@ -648,7 +647,7 @@ struct IntegrationV5Tests {
                 try await withThrowingTaskGroup { group in
                     group.addTask {
                         try await Task.sleep(for: .seconds(1))
-                        try await withSpan("test)") { span in
+                        try await tracer.withSpan("test)") { span in
                             cont.yield(span.context.inMemorySpanContext?.traceID ?? "1")
                             _ = try await connection.v5.publish(
                                 to: "traceContextPropagation",
@@ -663,7 +662,7 @@ struct IntegrationV5Tests {
                             subscription in
                             for try await message in subscription {
                                 try await connection.withMessageSpan(message) { span in
-                                    _ = cont.yield(span.context.inMemorySpanContext?.traceID ?? "1")
+                                    _ = cont.yield(span.context.inMemorySpanContext?.traceID ?? "2")
                                 }
                                 return
                             }

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -633,7 +633,6 @@ struct IntegrationV5Tests {
         var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
         config.tracing.tracer = tracer
 
-        let (stream, cont) = AsyncStream.makeStream(of: String.self)
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
             configuration: config,
@@ -644,39 +643,89 @@ struct IntegrationV5Tests {
                 configuration: config,
                 identifier: "traceContextPropagationSubscribe"
             ) { connection2 in
-                try await withThrowingTaskGroup { group in
+                try await withThrowingTaskGroup(of: String.self) { group in
                     group.addTask {
                         try await Task.sleep(for: .seconds(1))
-                        try await tracer.withSpan("test)") { span in
-                            cont.yield(span.context.inMemorySpanContext?.traceID ?? "1")
+                        return try await tracer.withSpan("test)") { span in
                             _ = try await connection.v5.publish(
                                 to: "traceContextPropagation",
                                 payload: ByteBuffer(string: "test"),
                                 qos: .atLeastOnce
                             )
+                            return span.context.inMemorySpanContext?.traceID ?? "Invalid publish trace id"
                         }
                     }
 
                     group.addTask {
                         try await connection2.v5.subscribe(to: [.init(topicFilter: "traceContextPropagation", qos: .atLeastOnce)]) {
                             subscription in
-                            for try await message in subscription {
-                                try await connection.withMessageSpan(message) { span in
-                                    _ = cont.yield(span.context.inMemorySpanContext?.traceID ?? "2")
+                            var subscriptionIterator = subscription.makeAsyncIterator()
+                            if let message = try await subscriptionIterator.next() {
+                                return try await connection.withMessageSpan(message) { span in
+                                    span?.context.inMemorySpanContext?.traceID ?? "No subscription trace id"
                                 }
-                                return
                             }
+                            return "No subscription"
                         }
                     }
-                    var iterator = stream.makeAsyncIterator()
-                    let publishContext = await iterator.next()
-                    let subscribeContext = await iterator.next()
+                    let publishContext = try await group.next()
+                    let subscribeContext = try await group.next()
                     // verify the context created by the publish
                     #expect(publishContext == subscribeContext)
-
-                    try await group.waitForAll()
                 }
             }
+        }
+
+        #expect(tracer.finishedSpans.count == 3)
+        let traceID = tracer.finishedSpans[0].traceID
+        #expect(tracer.finishedSpans[0].operationName == "PUBLISH")
+        #expect(tracer.finishedSpans[0].kind == .producer)
+        expectSpanAttributesIncludes(
+            tracer.finishedSpans[0].attributes,
+            [
+                "messaging.operation.name": "publish",
+                "messaging.system": "mqtt",
+                "messaging.destination.name": "traceContextPropagation",
+                "server.address": .string(Self.hostname),
+                "server.port": 1883,
+            ]
+        )
+        #expect(tracer.finishedSpans[2].traceID == traceID)
+        #expect(tracer.finishedSpans[2].kind == .consumer)
+        expectSpanAttributesIncludes(
+            tracer.finishedSpans[2].attributes,
+            [
+                "messaging.operation.name": "subscribe",
+                "messaging.system": "mqtt",
+                "messaging.destination.name": "traceContextPropagation",
+                "server.address": .string(Self.hostname),
+                "server.port": 1883,
+            ]
+        )
+    }
+
+    private func expectSpanAttributesIncludes(
+        _ lhs: @autoclosure () -> SpanAttributes,
+        _ rhs: @autoclosure () -> [String: SpanAttribute],
+        fileID: String = #fileID,
+        filePath: String = #filePath,
+        line: Int = #line,
+        column: Int = #column
+    ) {
+        var rhs = rhs()
+
+        // swift-format-ignore: ReplaceForEachWithForLoop
+        lhs().forEach { key, attribute in
+            if let rhsValue = rhs.removeValue(forKey: key) {
+                #expect(rhsValue == attribute, sourceLocation: .init(fileID: fileID, filePath: filePath, line: line, column: column))
+            }
+        }
+
+        if !rhs.isEmpty {
+            Issue.record(
+                #"Expected attributes "\#(rhs.keys)" are not present in actual attributes."#,
+                sourceLocation: .init(fileID: fileID, filePath: filePath, line: line, column: column)
+            )
         }
     }
 

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -14,6 +14,11 @@ import Testing
 
 @testable import MQTTNIO
 
+#if DistributedTracingSupport
+import InMemoryTracing
+import Tracing
+#endif
+
 #if canImport(Network)
 import NIOTransportServices
 #endif
@@ -619,4 +624,62 @@ struct IntegrationV5Tests {
             }
         }
     }
+
+    #if DistributedTracingSupport
+
+    @Test
+    func traceContextPropagation() async throws {
+        let tracer = InMemoryTracer()
+        InstrumentationSystem.bootstrap(tracer)
+        var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
+        config.tracing.tracer = tracer
+
+        let (stream, cont) = AsyncStream.makeStream(of: String.self)
+        try await MQTTConnection.withConnection(
+            address: .hostname(Self.hostname),
+            configuration: config,
+            identifier: "traceContextPropagationPublish"
+        ) { connection in
+            try await MQTTConnection.withConnection(
+                address: .hostname(Self.hostname),
+                configuration: config,
+                identifier: "traceContextPropagationSubscribe"
+            ) { connection2 in
+                try await withThrowingTaskGroup { group in
+                    group.addTask {
+                        try await Task.sleep(for: .seconds(1))
+                        try await withSpan("test)") { span in
+                            cont.yield(span.context.inMemorySpanContext?.traceID ?? "1")
+                            _ = try await connection.v5.publish(
+                                to: "traceContextPropagation",
+                                payload: ByteBuffer(string: "test"),
+                                qos: .atLeastOnce
+                            )
+                        }
+                    }
+
+                    group.addTask {
+                        try await connection2.v5.subscribe(to: [.init(topicFilter: "traceContextPropagation", qos: .atLeastOnce)]) {
+                            subscription in
+                            for try await message in subscription {
+                                try await connection.withMessageSpan(message) { span in
+                                    _ = cont.yield(span.context.inMemorySpanContext?.traceID ?? "1")
+                                }
+                                return
+                            }
+                        }
+                    }
+                    var iterator = stream.makeAsyncIterator()
+                    let publishContext = await iterator.next()
+                    let subscribeContext = await iterator.next()
+                    // verify the context created by the publish
+                    #expect(publishContext == subscribeContext)
+
+                    try await group.waitForAll()
+                }
+            }
+        }
+    }
+
+    #endif
 }

--- a/Tests/IntegrationTests/IntegrationV5Tests.swift
+++ b/Tests/IntegrationTests/IntegrationV5Tests.swift
@@ -632,11 +632,9 @@ struct IntegrationV5Tests {
         let tracer1 = InMemoryTracer()
         var config1 = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
         config1.tracing.tracer = tracer1
-        config1.tracing.createChildConsumerSpans = true
         let tracer2 = InMemoryTracer()
         var config2 = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
         config2.tracing.tracer = tracer2
-        config2.tracing.createChildConsumerSpans = true
 
         try await MQTTConnection.withConnection(
             address: .hostname(Self.hostname),
@@ -666,7 +664,7 @@ struct IntegrationV5Tests {
                             subscription in
                             var subscriptionIterator = subscription.makeAsyncIterator()
                             if let message = try await subscriptionIterator.next() {
-                                return try await connection2.withMessageSpan(message) { span in
+                                return try await connection2.withMessageSpan(message, createChildSpan: true) { span in
                                     span?.context.inMemorySpanContext?.traceID ?? "No subscription trace id"
                                 }
                             }

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -724,6 +724,7 @@ struct MQTTConnectionTests {
             let tracer = InMemoryTracer()
             var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
             config.tracing.tracer = tracer
+            config.tracing.createChildConsumerSpans = true
             try await withTestMQTTServer(configuration: config) { connection in
                 try await connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .atLeastOnce, retain: false)
             } server: { channel in
@@ -735,7 +736,7 @@ struct MQTTConnectionTests {
             }
             #expect(tracer.finishedSpans.count == 1)
             #expect(tracer.finishedSpans[0].kind == .producer)
-            #expect(tracer.finishedSpans[0].operationName == "PUBLISH testTopic")
+            #expect(tracer.finishedSpans[0].operationName == "publish testTopic")
             expectSpanAttributesEquals(
                 tracer.finishedSpans[0].attributes,
                 [
@@ -743,7 +744,6 @@ struct MQTTConnectionTests {
                     "messaging.system": "mqtt",
                     "messaging.destination.name": "testTopic",
                     "server.address": .string("127.0.0.1"),
-                    "server.port": 1883,
                     "network.peer.address": .string("127.0.0.1"),
                     "network.peer.port": 1883,
                 ]
@@ -755,6 +755,7 @@ struct MQTTConnectionTests {
             let tracer = InMemoryTracer()
             var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
             config.tracing.tracer = tracer
+            config.tracing.createChildConsumerSpans = true
             try await withTestMQTTServer(configuration: config) { connection in
                 try? await connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .atLeastOnce, retain: false)
             } server: { channel in
@@ -775,7 +776,6 @@ struct MQTTConnectionTests {
                     "messaging.system": "mqtt",
                     "messaging.destination.name": "testTopic",
                     "server.address": .string("127.0.0.1"),
-                    "server.port": 1883,
                     "network.peer.address": .string("127.0.0.1"),
                     "network.peer.port": 1883,
                 ]
@@ -787,6 +787,7 @@ struct MQTTConnectionTests {
             let tracer = InMemoryTracer()
             var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
             config.tracing.tracer = tracer
+            config.tracing.createChildConsumerSpans = true
             try await withTestMQTTServer(configuration: config) { connection in
                 try await connection.v5.subscribe(to: [.init(topicFilter: "subscribeAttributes", qos: .atMostOnce)]) { sub in
                     var iterator = sub.makeAsyncIterator()
@@ -843,7 +844,7 @@ struct MQTTConnectionTests {
                 try await channel.writeInboundPacket(unsuback, version: .v5_0)
             }
             #expect(tracer.finishedSpans.count == 1)
-            #expect(tracer.finishedSpans[0].operationName == "SUBSCRIBE subscribeAttributes")
+            #expect(tracer.finishedSpans[0].operationName == "subscribe subscribeAttributes")
             #expect(tracer.finishedSpans[0].kind == .consumer)
             expectSpanAttributesEquals(
                 tracer.finishedSpans[0].attributes,
@@ -852,7 +853,6 @@ struct MQTTConnectionTests {
                     "messaging.system": "mqtt",
                     "messaging.destination.name": "subscribeAttributes",
                     "server.address": .string("127.0.0.1"),
-                    "server.port": 1883,
                     "network.peer.address": .string("127.0.0.1"),
                     "network.peer.port": 1883,
                 ]

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -6,11 +6,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import InMemoryTracing
 import Logging
 import NIOCore
 import NIOEmbedded
 import NIOHTTP1
 import Testing
+import Tracing
 
 @testable import MQTTNIO
 
@@ -713,6 +715,100 @@ struct MQTTConnectionTests {
         } server: { _ in
         }
     }
+
+    #if DistributedTracingSupport
+
+    struct Tracing {
+        @Test("Publish attributes")
+        func publishAttributes() async throws {
+            let tracer = InMemoryTracer()
+            var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
+            config.tracing.tracer = tracer
+            try await withTestMQTTServer(configuration: config) { connection in
+                try await connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .atLeastOnce, retain: false)
+            } server: { channel in
+                let packet = try await channel.waitForOutboundPacket()
+                let publishPacket = try MQTTPublishPacket.read(version: .v5_0, from: packet)
+                #expect(publishPacket.packetId != 0)
+                let ack = MQTTPubAckPacket(type: .PUBACK, packetId: publishPacket.packetId)
+                try await channel.writeInboundPacket(ack, version: .v5_0)
+            }
+            #expect(tracer.finishedSpans.count == 1)
+            expectSpanAttributesEquals(
+                tracer.finishedSpans[0].attributes,
+                [
+                    "messaging.operation.name": "publish",
+                    "messaging.system": "mqtt",
+                    "messaging.destination.name": "testTopic",
+                    "server.address": .string("127.0.0.1"),
+                    "server.port": 1883,
+                    "network.peer.address": .string("127.0.0.1"),
+                    "network.peer.port": 1883,
+                ]
+            )
+        }
+
+        @Test("Publish error attributes")
+        func publishErrorAttributes() async throws {
+            let tracer = InMemoryTracer()
+            var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
+            config.tracing.tracer = tracer
+            try await withTestMQTTServer(configuration: config) { connection in
+                try? await connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .atLeastOnce, retain: false)
+            } server: { channel in
+                let packet = try await channel.waitForOutboundPacket()
+                let publishPacket = try MQTTPublishPacket.read(version: .v5_0, from: packet)
+                #expect(publishPacket.packetId != 0)
+                let ack = MQTTPubAckPacket(type: .PUBREC, packetId: publishPacket.packetId)
+                try await channel.writeInboundPacket(ack, version: .v5_0)
+            }
+            #expect(tracer.finishedSpans.count == 1)
+            expectSpanAttributesEquals(
+                tracer.finishedSpans[0].attributes,
+                [
+                    "messaging.operation.name": "publish",
+                    "messaging.system": "mqtt",
+                    "messaging.destination.name": "testTopic",
+                    "server.address": .string("127.0.0.1"),
+                    "server.port": 1883,
+                    "network.peer.address": .string("127.0.0.1"),
+                    "network.peer.port": 1883,
+                ]
+            )
+        }
+
+        private func expectSpanAttributesEquals(
+            _ lhs: @autoclosure () -> SpanAttributes,
+            _ rhs: @autoclosure () -> [String: SpanAttribute],
+            fileID: String = #fileID,
+            filePath: String = #filePath,
+            line: Int = #line,
+            column: Int = #column
+        ) {
+            var rhs = rhs()
+
+            // swift-format-ignore: ReplaceForEachWithForLoop
+            lhs().forEach { key, attribute in
+                if let rhsValue = rhs.removeValue(forKey: key) {
+                    #expect(rhsValue == attribute, sourceLocation: .init(fileID: fileID, filePath: filePath, line: line, column: column))
+                } else {
+                    Issue.record(
+                        #"Did not specify expected value for "\#(key)", actual value is "\#(attribute)"."#,
+                        sourceLocation: .init(fileID: fileID, filePath: filePath, line: line, column: column)
+                    )
+                }
+            }
+
+            if !rhs.isEmpty {
+                Issue.record(
+                    #"Expected attributes "\#(rhs.keys)" are not present in actual attributes."#,
+                    sourceLocation: .init(fileID: fileID, filePath: filePath, line: line, column: column)
+                )
+            }
+        }
+    }
+
+    #endif  // DistributedTracingSupport
 }
 
 struct SimpleAuthWorkflow: MQTTAuthenticator {

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -735,6 +735,7 @@ struct MQTTConnectionTests {
             }
             #expect(tracer.finishedSpans.count == 1)
             #expect(tracer.finishedSpans[0].kind == .producer)
+            #expect(tracer.finishedSpans[0].operationName == "PUBLISH testTopic")
             expectSpanAttributesEquals(
                 tracer.finishedSpans[0].attributes,
                 [
@@ -842,6 +843,7 @@ struct MQTTConnectionTests {
                 try await channel.writeInboundPacket(unsuback, version: .v5_0)
             }
             #expect(tracer.finishedSpans.count == 1)
+            #expect(tracer.finishedSpans[0].operationName == "SUBSCRIBE subscribeAttributes")
             #expect(tracer.finishedSpans[0].kind == .consumer)
             expectSpanAttributesEquals(
                 tracer.finishedSpans[0].attributes,

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -716,7 +716,7 @@ struct MQTTConnectionTests {
         }
     }
 
-    #if DistributedTracingSupport
+    #if DistributedTracing
 
     struct Tracing {
         @Test("Publish attributes")
@@ -890,7 +890,7 @@ struct MQTTConnectionTests {
         }
     }
 
-    #endif  // DistributedTracingSupport
+    #endif  // DistributedTracing
 }
 
 struct SimpleAuthWorkflow: MQTTAuthenticator {

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -734,6 +734,7 @@ struct MQTTConnectionTests {
                 try await channel.writeInboundPacket(ack, version: .v5_0)
             }
             #expect(tracer.finishedSpans.count == 1)
+            #expect(tracer.finishedSpans[0].kind == .producer)
             expectSpanAttributesEquals(
                 tracer.finishedSpans[0].attributes,
                 [
@@ -763,12 +764,91 @@ struct MQTTConnectionTests {
                 try await channel.writeInboundPacket(ack, version: .v5_0)
             }
             #expect(tracer.finishedSpans.count == 1)
+            #expect(tracer.finishedSpans[0].kind == .producer)
+            #expect(tracer.finishedSpans[0].errors.count == 1)
+            #expect(tracer.finishedSpans[0].errors[0].error is MQTTError)
             expectSpanAttributesEquals(
                 tracer.finishedSpans[0].attributes,
                 [
                     "messaging.operation.name": "publish",
                     "messaging.system": "mqtt",
                     "messaging.destination.name": "testTopic",
+                    "server.address": .string("127.0.0.1"),
+                    "server.port": 1883,
+                    "network.peer.address": .string("127.0.0.1"),
+                    "network.peer.port": 1883,
+                ]
+            )
+        }
+
+        @Test("Subscribe attributes")
+        func subscribeAttributes() async throws {
+            let tracer = InMemoryTracer()
+            var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
+            config.tracing.tracer = tracer
+            try await withTestMQTTServer(configuration: config) { connection in
+                try await connection.v5.subscribe(to: [.init(topicFilter: "subscribeAttributes", qos: .atMostOnce)]) { sub in
+                    var iterator = sub.makeAsyncIterator()
+                    let message = try #require(try await iterator.next())
+                    try await connection.withMessageSpan(message) { _ in
+                    }
+                }
+            } server: { channel in
+                // Receive SUBSCRIBE
+                var packet = try await channel.waitForOutboundPacket()
+                let subscribePacket = try MQTTSubscribePacket.read(version: .v5_0, from: packet)
+                let subscriptionID: UInt32 = try #require(
+                    {
+                        for property in subscribePacket.properties ?? .init() {
+                            if case .subscriptionIdentifier(let id) = property {
+                                return id
+                            }
+                        }
+                        return nil
+                    }()
+                )
+                // Send SUBACK
+                let suback = MQTTSubAckPacket(
+                    type: .SUBACK,
+                    packetId: subscribePacket.packetId,
+                    reasons: [.success],
+                    properties: .init()
+                )
+                try await channel.writeInboundPacket(suback, version: .v5_0)
+
+                // send PUBLISH
+                let publish2 = MQTTPublishPacket(
+                    publish: .init(
+                        qos: .atMostOnce,
+                        retain: false,
+                        topicName: "subscribeAttributes",
+                        payload: ByteBuffer(string: "TestPayload2"),
+                        properties: [.subscriptionIdentifier(subscriptionID)]
+                    ),
+                    packetId: 32769
+                )
+                try await channel.writeInboundPacket(publish2, version: .v5_0)
+
+                // Receive UNSUBSCRIBE
+                packet = try await channel.waitForOutboundPacket()
+                let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v5_0, from: packet)
+                // Send UNSUBACK
+                let unsuback = MQTTSubAckPacket(
+                    type: .UNSUBACK,
+                    packetId: unsubscribePacket.packetId,
+                    reasons: [.success],
+                    properties: .init()
+                )
+                try await channel.writeInboundPacket(unsuback, version: .v5_0)
+            }
+            #expect(tracer.finishedSpans.count == 1)
+            #expect(tracer.finishedSpans[0].kind == .consumer)
+            expectSpanAttributesEquals(
+                tracer.finishedSpans[0].attributes,
+                [
+                    "messaging.operation.name": "subscribe",
+                    "messaging.system": "mqtt",
+                    "messaging.destination.name": "subscribeAttributes",
                     "server.address": .string("127.0.0.1"),
                     "server.port": 1883,
                     "network.peer.address": .string("127.0.0.1"),

--- a/Tests/MQTTNIOTests/MQTTConnectionTests.swift
+++ b/Tests/MQTTNIOTests/MQTTConnectionTests.swift
@@ -6,15 +6,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import InMemoryTracing
 import Logging
 import NIOCore
 import NIOEmbedded
 import NIOHTTP1
 import Testing
-import Tracing
 
 @testable import MQTTNIO
+
+#if DistributedTracing
+import InMemoryTracing
+import Tracing
+#endif
 
 @Suite("MQTTConnection Tests", .defaultLogger(logLevel: .trace))
 struct MQTTConnectionTests {
@@ -724,7 +727,6 @@ struct MQTTConnectionTests {
             let tracer = InMemoryTracer()
             var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
             config.tracing.tracer = tracer
-            config.tracing.createChildConsumerSpans = true
             try await withTestMQTTServer(configuration: config) { connection in
                 try await connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .atLeastOnce, retain: false)
             } server: { channel in
@@ -755,7 +757,6 @@ struct MQTTConnectionTests {
             let tracer = InMemoryTracer()
             var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
             config.tracing.tracer = tracer
-            config.tracing.createChildConsumerSpans = true
             try await withTestMQTTServer(configuration: config) { connection in
                 try? await connection.publish(to: "testTopic", payload: ByteBuffer(string: "TestPayload"), qos: .atLeastOnce, retain: false)
             } server: { channel in
@@ -787,12 +788,11 @@ struct MQTTConnectionTests {
             let tracer = InMemoryTracer()
             var config = MQTTConnectionConfiguration(versionConfiguration: .v5_0())
             config.tracing.tracer = tracer
-            config.tracing.createChildConsumerSpans = true
             try await withTestMQTTServer(configuration: config) { connection in
                 try await connection.v5.subscribe(to: [.init(topicFilter: "subscribeAttributes", qos: .atMostOnce)]) { sub in
                     var iterator = sub.makeAsyncIterator()
                     let message = try #require(try await iterator.next())
-                    try await connection.withMessageSpan(message) { _ in
+                    try await connection.withMessageSpan(message, createChildSpan: true) { _ in
                     }
                 }
             } server: { channel in

--- a/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
+++ b/Tests/MQTTNIOTests/Utils/MQTTConnectionTests+withTest.swift
@@ -13,125 +13,255 @@ import Testing
 
 @testable import MQTTNIO
 
-extension MQTTConnectionTests {
-    /// Helper function to test an ``MQTTConnection`` with a test MQTT server using `NIOAsyncTestingChannel`.
-    ///
-    /// This function sets up a test MQTT server and establishes a connection using the provided configuration and session.
-    /// It then performs the specified client and server operations concurrently, allowing for testing of various MQTT interactions.
-    ///
-    /// - Parameters:
-    ///   - configuration: The configuration to use for the MQTT connection.
-    ///   - session: The MQTT session to use for the connection.
-    ///   - connackProperties: The properties to include in the CONNACK packet.
-    ///   - clientOperation: An async operation to perform for the client side of the test.
-    ///         The ``MQTTConnection`` will be passed as a parameter to this operation.
-    ///   - serverOperation: An async operation to perform for the server side of the test.
-    ///         The test MQTT server channel will be passed as a parameter to this operation.
-    func withTestMQTTServer(
-        configuration: MQTTConnectionConfiguration = .init(),
-        session: MQTTSession = MQTTSession(clientID: ""),
-        connackProperties: MQTTProperties = .init(),
-        client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
-        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
-    ) async throws {
-        let channel = NIOAsyncTestingChannel()
-        do {
-            try await session.storage.mutatingBorrow { sessionStorage -> (MQTTSessionStorage, Result<Void, any Error>) in
-                let connection: MQTTConnection
+/// Helper function to test an ``MQTTConnection`` with a test MQTT server using `NIOAsyncTestingChannel`.
+///
+/// This function sets up a test MQTT server and establishes a connection using the provided configuration and session.
+/// It then performs the specified client and server operations concurrently, allowing for testing of various MQTT interactions.
+///
+/// - Parameters:
+///   - configuration: The configuration to use for the MQTT connection.
+///   - session: The MQTT session to use for the connection.
+///   - connackProperties: The properties to include in the CONNACK packet.
+///   - clientOperation: An async operation to perform for the client side of the test.
+///         The ``MQTTConnection`` will be passed as a parameter to this operation.
+///   - serverOperation: An async operation to perform for the server side of the test.
+///         The test MQTT server channel will be passed as a parameter to this operation.
+func withTestMQTTServer(
+    configuration: MQTTConnectionConfiguration = .init(),
+    session: MQTTSession = MQTTSession(clientID: ""),
+    connackProperties: MQTTProperties = .init(),
+    client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
+    server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
+) async throws {
+    let channel = NIOAsyncTestingChannel()
+    do {
+        try await session.storage.mutatingBorrow { sessionStorage -> (MQTTSessionStorage, Result<Void, any Error>) in
+            let connection: MQTTConnection
+            do {
+                connection = try await MQTTConnection.setupChannelAndConnect(
+                    channel,
+                    configuration: configuration,
+                    session: sessionStorage
+                )
+            } catch {
+                return (sessionStorage, .failure(error))
+            }
+            let version = configuration.version
+            return await withTaskGroup(of: (MQTTSessionStorage, Result<Void, any Error>).self) { group in
+                group.addTask {
+                    do {
+                        _ = try await connection.sendConnect(clientID: sessionStorage.clientID, cleanSession: sessionStorage.clientID.isEmpty)
+                    } catch {
+                        let sessionStorage = await connection.closeAndCleanup(sendDisconnect: false)
+                        return (sessionStorage, .failure(error))
+                    }
+                    // stick this in an unstructured task to avoid cancellation on iterating the subscribe
+                    // request queue. TODO: use `withTaskCancellationShield` when Swift 6.4 comes out
+                    let task = Task { await connection.handleSessionSubscriptionTasks(session: session) }
+                    do {
+                        try await clientOperation(connection)
+                        session.subscriptionsQueueContinuation.yield(.cancel)
+                        await task.value
+                        let sessionStorage = await connection.closeAndCleanup()
+                        return (sessionStorage, .success(()))
+                    } catch {
+                        session.subscriptionsQueueContinuation.yield(.cancel)
+                        await task.value
+                        let sessionStorage = await connection.closeAndCleanup()
+                        return (sessionStorage, .failure(error))
+                    }
+                }
                 do {
-                    connection = try await MQTTConnection.setupChannelAndConnect(
-                        channel,
-                        configuration: configuration,
-                        session: sessionStorage
-                    )
+                    // wait for connect
+                    let packet = try await channel.waitForOutboundPacket()
+                    let connect = try MQTTConnectPacket.read(version: configuration.version, from: packet)
+                    #expect(connect.cleanSession == sessionStorage.clientID.isEmpty)
+                    #expect(connect.clientIdentifier == sessionStorage.clientID)
+                    if case .v5_0(var connectProperties, _, _, let authWorkflow) = configuration.versionConfiguration {
+                        if let authWorkflow {
+                            connectProperties.append(.authenticationMethod(authWorkflow.methodName))
+                        }
+                        #expect(connectProperties == connect.properties)
+                    }
+
+                    let connack = MQTTConnAckPacket(returnCode: 0, acknowledgeFlags: 1, properties: connackProperties)
+                    try await channel.writeInboundPacket(connack, version: version)
+
+                    try await serverOperation(channel)
+
+                    // wait for disconnect
+                    let disconnectPacket = try await channel.waitForOutboundPacket()
+                    #expect(disconnectPacket.type == .DISCONNECT)
+                    #expect(disconnectPacket.packetId == 0)
                 } catch {
                     return (sessionStorage, .failure(error))
                 }
-                let version = configuration.version
-                return await withTaskGroup(of: (MQTTSessionStorage, Result<Void, any Error>).self) { group in
-                    group.addTask {
-                        do {
-                            _ = try await connection.sendConnect(clientID: sessionStorage.clientID, cleanSession: sessionStorage.clientID.isEmpty)
-                        } catch {
-                            let sessionStorage = await connection.closeAndCleanup(sendDisconnect: false)
-                            return (sessionStorage, .failure(error))
-                        }
-                        // stick this in an unstructured task to avoid cancellation on iterating the subscribe
-                        // request queue. TODO: use `withTaskCancellationShield` when Swift 6.4 comes out
-                        let task = Task { await connection.handleSessionSubscriptionTasks(session: session) }
-                        do {
-                            try await clientOperation(connection)
-                            session.subscriptionsQueueContinuation.yield(.cancel)
-                            await task.value
-                            let sessionStorage = await connection.closeAndCleanup()
-                            return (sessionStorage, .success(()))
-                        } catch {
-                            session.subscriptionsQueueContinuation.yield(.cancel)
-                            await task.value
-                            let sessionStorage = await connection.closeAndCleanup()
-                            return (sessionStorage, .failure(error))
-                        }
+
+                return await group.next()!
+            }
+        }
+    } catch UniqueReferenceError.alreadyBorrowed {
+        throw MQTTError.alreadyConnectedWithSession
+    }
+}
+
+/// Helper function to create a ``MQTTSubscription`` with a test MQTT server.
+///
+/// - Parameters:
+///   - subscribeInfos: An array of ``MQTTSubscribeInfo`` to subscribe to for this subscription.
+///   - clientOperation: An async operation to perform for the subscription opened via the connection.
+///         The opened subscription will be passed as a parameter to this operation.
+///   - serverOperation: An async operation to perform for the subscription on the server side.
+///         The test MQTT server channel will be passed as a parameter to this operation.
+func withTestSubscription(
+    subscribeInfos: [MQTTSubscribeInfo],
+    client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+    server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
+) async throws {
+    try await withTestMQTTServer { connection in
+        try await connection.subscribe(to: subscribeInfos) { sub in
+            try await clientOperation(sub)
+        }
+    } server: { channel in
+        // Receive SUBSCRIBE
+        var packet = try await channel.waitForOutboundPacket()
+        let subscribePacket = try MQTTSubscribePacket.read(version: .v3_1_1, from: packet)
+        #expect(subscribeInfos.count == subscribePacket.subscriptions.count)
+        for index in 0..<subscribePacket.subscriptions.count {
+            #expect(subscribePacket.subscriptions[index].topicFilter == subscribeInfos[index].topicFilter)
+            #expect(subscribePacket.subscriptions[index].qos == subscribeInfos[index].qos)
+        }
+        // Send SUBACK
+        let suback = MQTTSubAckPacket(
+            type: .SUBACK,
+            packetId: subscribePacket.packetId,
+            reasons: subscribeInfos.map { _ in .success },
+            properties: .init()
+        )
+        try await channel.writeInboundPacket(suback, version: .v3_1_1)
+
+        try await serverOperation(channel)
+
+        // Receive UNSUBSCRIBE
+        packet = try await channel.waitForOutboundPacket()
+        let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v3_1_1, from: packet)
+        #expect(unsubscribePacket.subscriptions == subscribeInfos.map { $0.topicFilter })
+        // Send UNSUBACK
+        let unsuback = MQTTSubAckPacket(
+            type: .UNSUBACK,
+            packetId: unsubscribePacket.packetId,
+            reasons: subscribeInfos.map { _ in .success },
+            properties: .init()
+        )
+        try await channel.writeInboundPacket(unsuback, version: .v3_1_1)
+    }
+}
+
+/// Helper function to create a ``MQTTSubscription`` with a test MQTT server using MQTT v5.
+///
+/// - Parameters:
+///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
+///   - clientOperation: An async operation to perform for the subscription opened via the connection.
+///         The opened subscription will be passed as a parameter to this operation.
+///   - serverOperation: An async operation to perform for the subscription on the server side.
+///         The test MQTT server channel will be passed as a parameter to this operation.
+///         The subscription identifier will also be passed as a parameter.
+func withTestV5Subscription(
+    subscribeInfos: [MQTTSubscribeInfoV5],
+    client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+    server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel, UInt32) async throws -> Void,
+) async throws {
+    try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0())) { connection in
+        try await connection.v5.subscribe(to: subscribeInfos) { sub in
+            try await clientOperation(sub)
+        }
+    } server: { channel in
+        // Receive SUBSCRIBE
+        var packet = try await channel.waitForOutboundPacket()
+        let subscribePacket = try MQTTSubscribePacket.read(version: .v5_0, from: packet)
+        #expect(subscribeInfos.count == subscribePacket.subscriptions.count)
+        for index in 0..<subscribePacket.subscriptions.count {
+            #expect(subscribePacket.subscriptions[index].topicFilter == subscribeInfos[index].topicFilter)
+            #expect(subscribePacket.subscriptions[index].qos == subscribeInfos[index].qos)
+        }
+        let properties = try #require(subscribePacket.properties)
+        let subscriptionId: UInt32 = try #require(
+            {
+                for property in properties {
+                    if case .subscriptionIdentifier(let id) = property {
+                        return id
                     }
-                    do {
-                        // wait for connect
-                        let packet = try await channel.waitForOutboundPacket()
-                        let connect = try MQTTConnectPacket.read(version: configuration.version, from: packet)
-                        #expect(connect.cleanSession == sessionStorage.clientID.isEmpty)
-                        #expect(connect.clientIdentifier == sessionStorage.clientID)
-                        if case .v5_0(var connectProperties, _, _, let authWorkflow) = configuration.versionConfiguration {
-                            if let authWorkflow {
-                                connectProperties.append(.authenticationMethod(authWorkflow.methodName))
-                            }
-                            #expect(connectProperties == connect.properties)
-                        }
+                }
+                return nil
+            }()
+        )
+        // Send SUBACK
+        let suback = MQTTSubAckPacket(
+            type: .SUBACK,
+            packetId: subscribePacket.packetId,
+            reasons: subscribeInfos.map { _ in .success },
+            properties: .init()
+        )
+        try await channel.writeInboundPacket(suback, version: .v5_0)
 
-                        let connack = MQTTConnAckPacket(returnCode: 0, acknowledgeFlags: 1, properties: connackProperties)
-                        try await channel.writeInboundPacket(connack, version: version)
+        try await serverOperation(channel, subscriptionId)
 
-                        try await serverOperation(channel)
+        // Receive UNSUBSCRIBE
+        packet = try await channel.waitForOutboundPacket()
+        let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v5_0, from: packet)
+        #expect(unsubscribePacket.subscriptions == subscribeInfos.map { $0.topicFilter })
+        // Send UNSUBACK
+        let unsuback = MQTTSubAckPacket(
+            type: .UNSUBACK,
+            packetId: unsubscribePacket.packetId,
+            reasons: subscribeInfos.map { _ in .success },
+            properties: .init()
+        )
+        try await channel.writeInboundPacket(unsuback, version: .v5_0)
+    }
+}
 
-                        // wait for disconnect
-                        let disconnectPacket = try await channel.waitForOutboundPacket()
-                        #expect(disconnectPacket.type == .DISCONNECT)
-                        #expect(disconnectPacket.packetId == 0)
-                    } catch {
-                        return (sessionStorage, .failure(error))
+/// Helper function to test multiple ``MQTTSession`` subscriptions with a test MQTT server.
+///
+/// For each array of ``MQTTSubscribeInfoV5``, a session subscription will be created
+/// and the same `clientOperation` and `serverOperation` will be performed for each subscription.
+///
+/// - Parameters:
+///   - subscribeInfos: An array of arrays of ``MQTTSubscribeInfoV5`` to subscribe to.
+///         Each inner array represents a separate subscription.
+///   - subscribeOperation: An async operation to perform for each subscription opened via the session.
+///         The opened subscription will be passed as a parameter to this operation.
+///   - clientOperation: An async operation to perform for the client side of the test.
+///         The ``MQTTConnection`` will be passed as a parameter to this operation.
+///   - serverOperation: An async operation to perform for each subscription on the server side.
+///         The test MQTT server channel will be passed as a parameter to this operation.
+func withTestSessionSubscriptions(
+    to subscribeInfos: [[MQTTSubscribeInfoV5]],
+    subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+    client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
+    server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
+) async throws {
+    let session = MQTTSession(clientID: UUID().uuidString)
+    let (stream, cont) = AsyncStream.makeStream(of: Void.self)
+    try await withTestMQTTServer(session: session) { connection in
+        try await withThrowingTaskGroup { group in
+            for subscribeInfo in subscribeInfos {
+                group.addTask {
+                    try await session.subscribe(to: subscribeInfo) { subscription in
+                        try await subscribeOperation(subscription)
                     }
-
-                    return await group.next()!
                 }
             }
-        } catch UniqueReferenceError.alreadyBorrowed {
-            throw MQTTError.alreadyConnectedWithSession
+            // Make sure all subscriptions have been called before running
+            // client operation
+            await stream.first { _ in true }
+            try await clientOperation(connection)
         }
-    }
-
-    /// Helper function to create a ``MQTTSubscription`` with a test MQTT server.
-    ///
-    /// - Parameters:
-    ///   - subscribeInfos: An array of ``MQTTSubscribeInfo`` to subscribe to for this subscription.
-    ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
-    ///         The opened subscription will be passed as a parameter to this operation.
-    ///   - serverOperation: An async operation to perform for the subscription on the server side.
-    ///         The test MQTT server channel will be passed as a parameter to this operation.
-    func withTestSubscription(
-        subscribeInfos: [MQTTSubscribeInfo],
-        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
-        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void,
-    ) async throws {
-        try await withTestMQTTServer { connection in
-            try await connection.subscribe(to: subscribeInfos) { sub in
-                try await clientOperation(sub)
-            }
-        } server: { channel in
+    } server: { channel in
+        for _ in subscribeInfos {
             // Receive SUBSCRIBE
-            var packet = try await channel.waitForOutboundPacket()
+            let packet = try await channel.waitForOutboundPacket()
             let subscribePacket = try MQTTSubscribePacket.read(version: .v3_1_1, from: packet)
-            #expect(subscribeInfos.count == subscribePacket.subscriptions.count)
-            for index in 0..<subscribePacket.subscriptions.count {
-                #expect(subscribePacket.subscriptions[index].topicFilter == subscribeInfos[index].topicFilter)
-                #expect(subscribePacket.subscriptions[index].qos == subscribeInfos[index].qos)
-            }
             // Send SUBACK
             let suback = MQTTSubAckPacket(
                 type: .SUBACK,
@@ -140,13 +270,14 @@ extension MQTTConnectionTests {
                 properties: .init()
             )
             try await channel.writeInboundPacket(suback, version: .v3_1_1)
+        }
+        cont.yield()
+        try await serverOperation(channel)
 
-            try await serverOperation(channel)
-
+        for _ in subscribeInfos {
             // Receive UNSUBSCRIBE
-            packet = try await channel.waitForOutboundPacket()
+            let packet = try await channel.waitForOutboundPacket()
             let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v3_1_1, from: packet)
-            #expect(unsubscribePacket.subscriptions == subscribeInfos.map { $0.topicFilter })
             // Send UNSUBACK
             let unsuback = MQTTSubAckPacket(
                 type: .UNSUBACK,
@@ -157,161 +288,28 @@ extension MQTTConnectionTests {
             try await channel.writeInboundPacket(unsuback, version: .v3_1_1)
         }
     }
+}
 
-    /// Helper function to create a ``MQTTSubscription`` with a test MQTT server using MQTT v5.
-    ///
-    /// - Parameters:
-    ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
-    ///   - clientOperation: An async operation to perform for the subscription opened via the connection.
-    ///         The opened subscription will be passed as a parameter to this operation.
-    ///   - serverOperation: An async operation to perform for the subscription on the server side.
-    ///         The test MQTT server channel will be passed as a parameter to this operation.
-    ///         The subscription identifier will also be passed as a parameter.
-    func withTestV5Subscription(
-        subscribeInfos: [MQTTSubscribeInfoV5],
-        client clientOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
-        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel, UInt32) async throws -> Void,
-    ) async throws {
-        try await withTestMQTTServer(configuration: .init(versionConfiguration: .v5_0())) { connection in
-            try await connection.v5.subscribe(to: subscribeInfos) { sub in
-                try await clientOperation(sub)
-            }
-        } server: { channel in
-            // Receive SUBSCRIBE
-            var packet = try await channel.waitForOutboundPacket()
-            let subscribePacket = try MQTTSubscribePacket.read(version: .v5_0, from: packet)
-            #expect(subscribeInfos.count == subscribePacket.subscriptions.count)
-            for index in 0..<subscribePacket.subscriptions.count {
-                #expect(subscribePacket.subscriptions[index].topicFilter == subscribeInfos[index].topicFilter)
-                #expect(subscribePacket.subscriptions[index].qos == subscribeInfos[index].qos)
-            }
-            let properties = try #require(subscribePacket.properties)
-            let subscriptionId: UInt32 = try #require(
-                {
-                    for property in properties {
-                        if case .subscriptionIdentifier(let id) = property {
-                            return id
-                        }
-                    }
-                    return nil
-                }()
-            )
-            // Send SUBACK
-            let suback = MQTTSubAckPacket(
-                type: .SUBACK,
-                packetId: subscribePacket.packetId,
-                reasons: subscribeInfos.map { _ in .success },
-                properties: .init()
-            )
-            try await channel.writeInboundPacket(suback, version: .v5_0)
-
-            try await serverOperation(channel, subscriptionId)
-
-            // Receive UNSUBSCRIBE
-            packet = try await channel.waitForOutboundPacket()
-            let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v5_0, from: packet)
-            #expect(unsubscribePacket.subscriptions == subscribeInfos.map { $0.topicFilter })
-            // Send UNSUBACK
-            let unsuback = MQTTSubAckPacket(
-                type: .UNSUBACK,
-                packetId: unsubscribePacket.packetId,
-                reasons: subscribeInfos.map { _ in .success },
-                properties: .init()
-            )
-            try await channel.writeInboundPacket(unsuback, version: .v5_0)
-        }
-    }
-
-    /// Helper function to test multiple ``MQTTSession`` subscriptions with a test MQTT server.
-    ///
-    /// For each array of ``MQTTSubscribeInfoV5``, a session subscription will be created
-    /// and the same `clientOperation` and `serverOperation` will be performed for each subscription.
-    ///
-    /// - Parameters:
-    ///   - subscribeInfos: An array of arrays of ``MQTTSubscribeInfoV5`` to subscribe to.
-    ///         Each inner array represents a separate subscription.
-    ///   - subscribeOperation: An async operation to perform for each subscription opened via the session.
-    ///         The opened subscription will be passed as a parameter to this operation.
-    ///   - clientOperation: An async operation to perform for the client side of the test.
-    ///         The ``MQTTConnection`` will be passed as a parameter to this operation.
-    ///   - serverOperation: An async operation to perform for each subscription on the server side.
-    ///         The test MQTT server channel will be passed as a parameter to this operation.
-    func withTestSessionSubscriptions(
-        to subscribeInfos: [[MQTTSubscribeInfoV5]],
-        subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
-        client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
-        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
-    ) async throws {
-        let session = MQTTSession(clientID: UUID().uuidString)
-        let (stream, cont) = AsyncStream.makeStream(of: Void.self)
-        try await withTestMQTTServer(session: session) { connection in
-            try await withThrowingTaskGroup { group in
-                for subscribeInfo in subscribeInfos {
-                    group.addTask {
-                        try await session.subscribe(to: subscribeInfo) { subscription in
-                            try await subscribeOperation(subscription)
-                        }
-                    }
-                }
-                // Make sure all subscriptions have been called before running
-                // client operation
-                await stream.first { _ in true }
-                try await clientOperation(connection)
-            }
-        } server: { channel in
-            for _ in subscribeInfos {
-                // Receive SUBSCRIBE
-                let packet = try await channel.waitForOutboundPacket()
-                let subscribePacket = try MQTTSubscribePacket.read(version: .v3_1_1, from: packet)
-                // Send SUBACK
-                let suback = MQTTSubAckPacket(
-                    type: .SUBACK,
-                    packetId: subscribePacket.packetId,
-                    reasons: subscribeInfos.map { _ in .success },
-                    properties: .init()
-                )
-                try await channel.writeInboundPacket(suback, version: .v3_1_1)
-            }
-            cont.yield()
-            try await serverOperation(channel)
-
-            for _ in subscribeInfos {
-                // Receive UNSUBSCRIBE
-                let packet = try await channel.waitForOutboundPacket()
-                let unsubscribePacket = try MQTTUnsubscribePacket.read(version: .v3_1_1, from: packet)
-                // Send UNSUBACK
-                let unsuback = MQTTSubAckPacket(
-                    type: .UNSUBACK,
-                    packetId: unsubscribePacket.packetId,
-                    reasons: subscribeInfos.map { _ in .success },
-                    properties: .init()
-                )
-                try await channel.writeInboundPacket(unsuback, version: .v3_1_1)
-            }
-        }
-    }
-
-    /// Helper function to test a ``MQTTSession`` subscription with a test MQTT server.
-    ///
-    /// - Parameters:
-    ///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
-    ///   - subscribeOperation: An async operation to perform for the subscription opened via the session.
-    ///         The opened subscription will be passed as a parameter to this operation.
-    ///   - clientOperation: An async operation to perform for the client side of the test.
-    ///         The ``MQTTConnection`` will be passed as a parameter to this operation.
-    ///   - serverOperation: An async operation to perform for the subscription on the server side.
-    ///         The test MQTT server channel will be passed as a parameter to this operation.
-    func withTestSessionSubscription(
-        to subscribeInfos: [MQTTSubscribeInfoV5],
-        subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
-        client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
-        server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
-    ) async throws {
-        try await withTestSessionSubscriptions(
-            to: [subscribeInfos],
-            subscribe: subscribeOperation,
-            client: clientOperation,
-            server: serverOperation
-        )
-    }
+/// Helper function to test a ``MQTTSession`` subscription with a test MQTT server.
+///
+/// - Parameters:
+///   - subscribeInfos: An array of ``MQTTSubscribeInfoV5`` to subscribe to for this subscription.
+///   - subscribeOperation: An async operation to perform for the subscription opened via the session.
+///         The opened subscription will be passed as a parameter to this operation.
+///   - clientOperation: An async operation to perform for the client side of the test.
+///         The ``MQTTConnection`` will be passed as a parameter to this operation.
+///   - serverOperation: An async operation to perform for the subscription on the server side.
+///         The test MQTT server channel will be passed as a parameter to this operation.
+func withTestSessionSubscription(
+    to subscribeInfos: [MQTTSubscribeInfoV5],
+    subscribe subscribeOperation: @Sendable @escaping (MQTTSubscription) async throws -> Void,
+    client clientOperation: @Sendable @escaping (MQTTConnection) async throws -> Void,
+    server serverOperation: @Sendable @escaping (NIOAsyncTestingChannel) async throws -> Void
+) async throws {
+    try await withTestSessionSubscriptions(
+        to: [subscribeInfos],
+        subscribe: subscribeOperation,
+        client: clientOperation,
+        server: serverOperation
+    )
 }


### PR DESCRIPTION
Add support for tracing. 
Publish spans are created automatically as long as you have set a tracer.
The trace context is then propagated via MQTTPublishInfo user properties
Can't easily create spans for subscriptions automatically, so added a function `MQTTConnection.withMessageSpan()` to extract trace context from MQTTPublishInfo

So subscriptions would work like this
```swift
for try await message in subscription {
    try await connection.withMessageSpan(message) { span in
        doStuff()
    }
}
```